### PR TITLE
Adds support for `componentDidCatch()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,15 @@ function renderToString(vnode, context, opts, inner, isSvgMode) {
 				c._disable = c.__x = true;
 				c.props = props;
 				c.context = context;
-				if (nodeName.getDerivedStateFromProps) c.state = assign(assign({}, c.state), nodeName.getDerivedStateFromProps(c.props, c.state));
-				else if (c.componentWillMount) c.componentWillMount();
-				rendered = c.render(c.props, c.state, c.context);
+				try {
+					if (nodeName.getDerivedStateFromProps) c.state = assign(assign({}, c.state), nodeName.getDerivedStateFromProps(c.props, c.state));
+					else if (c.componentWillMount) c.componentWillMount();
+					rendered = c.render(c.props, c.state, c.context);
+				}
+				catch (error) {
+					if (c.componentDidCatch) c.componentDidCatch(error);
+					else throw error;
+				}
 
 				if (c.getChildContext) {
 					context = assign(assign({}, context), c.getChildContext());

--- a/src/index.js
+++ b/src/index.js
@@ -54,13 +54,13 @@ function renderToString(vnode, context, opts, inner, isSvgMode) {
 
 	// components
 	if (typeof nodeName==='function') {
-		let c;
 		isComponent = true;
 		if (opts.shallow && (inner || opts.renderRootComponent===false)) {
 			nodeName = getComponentName(nodeName);
 		}
 		else {
-			let props = getNodeProps(vnode),
+			let c,
+				props = getNodeProps(vnode),
 				rendered;
 
 			if (!nodeName.prototype || typeof nodeName.prototype.render!=='function') {

--- a/test/render.js
+++ b/test/render.js
@@ -613,10 +613,9 @@ describe('render', () => {
 
 	describe('Error Handling', () => {
 		it('should invoke componentDidCatch from an error thrown in getDerivedStateFromProps', () => {
-			const error = new Error();
 			class Test extends Component {
 				static getDerivedStateFromProps() {
-					throw error;
+					throw new Error();
 				}
 				componentDidCatch(error) {}
 			}

--- a/test/render.js
+++ b/test/render.js
@@ -619,13 +619,13 @@ describe('render', () => {
 				}
 				componentDidCatch(error) {}
 				render(props) {
-					return <div {...props} />; // eslint-disable-line
+					return <div {...props} />;
 				}
 			}
 			class ComponentThatRenders extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <div {...props} />; // eslint-disable-line
+					return <div {...props} />;
 				}
 			}
 			class ErrorBoundry extends Component {
@@ -636,8 +636,8 @@ describe('render', () => {
 				componentDidCatch(error) {
 					this.setState({ throwError: false });
 				}
-				render(props, state) {
-					return state.throwError
+				render(props, { throwError }) {
+					return throwError
 						? <ComponentThatThrows />
 						: <ComponentThatRenders />;
 				}
@@ -662,15 +662,13 @@ describe('render', () => {
 			render(<App />);
 
 			// ComponentThatThrows
+			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
+				.to.have.been.calledOnce
+				.and.to.throw();
+
 			expect(ComponentThatThrows.prototype.componentDidCatch)
 				.to.not.have.been.called;
-
-			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
-				.to.have.been.calledOnce;
-			
-			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
-				.to.throw();
-
+	
 			expect(ComponentThatThrows.prototype.render)
 				.to.not.have.been.called;
 
@@ -679,10 +677,8 @@ describe('render', () => {
 				.to.not.have.been.called;
 			
 			expect(ComponentThatRenders.prototype.render)
-				.to.have.been.calledOnce;
-
-			expect(ComponentThatRenders.prototype.render)
-				.to.not.throw();
+				.to.have.been.calledOnce
+				.and.to.not.throw();
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)
@@ -706,13 +702,13 @@ describe('render', () => {
 				}
 				componentDidCatch(error) {}
 				render(props) {
-					return <div {...props} />; // eslint-disable-line
+					return <div {...props} />;
 				}
 			}
 			class ComponentThatRenders extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <div {...props} />; // eslint-disable-line
+					return <div {...props} />;
 				}
 			}
 			class ErrorBoundry extends Component {
@@ -723,8 +719,8 @@ describe('render', () => {
 				componentDidCatch(error) {
 					this.setState({ throwError: false });
 				}
-				render(props, state) {
-					return state.throwError
+				render(props, { throwError }) {
+					return throwError
 						? <ComponentThatThrows />
 						: <ComponentThatRenders />;
 				}
@@ -753,10 +749,8 @@ describe('render', () => {
 				.to.not.have.been.called;
 
 			expect(ComponentThatThrows.prototype.componentWillMount)
-				.to.have.been.calledOnce;
-			
-			expect(ComponentThatThrows.prototype.componentWillMount)
-				.to.throw();
+				.to.have.been.calledOnce
+				.and.to.throw();
 
 			expect(ComponentThatThrows.prototype.render)
 				.to.not.have.been.called;
@@ -766,10 +760,8 @@ describe('render', () => {
 				.to.not.have.been.called;
 			
 			expect(ComponentThatRenders.prototype.render)
-				.to.have.been.calledOnce;
-
-			expect(ComponentThatRenders.prototype.render)
-				.to.not.throw();
+				.to.have.been.calledOnce
+				.and.to.not.throw();
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)
@@ -797,7 +789,7 @@ describe('render', () => {
 			class ComponentThatRenders extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <div {...props} />; // eslint-disable-line
+					return <div {...props} />;
 				}
 			}
 			class ErrorBoundry extends Component {
@@ -808,8 +800,8 @@ describe('render', () => {
 				componentDidCatch(error) {
 					this.setState({ throwError: false });
 				}
-				render(props, state) {
-					return state.throwError
+				render(props, { throwError }) {
+					return throwError
 						? <ComponentThatThrows />
 						: <ComponentThatRenders />;
 				}
@@ -837,20 +829,16 @@ describe('render', () => {
 				.to.not.have.been.called;
 
 			expect(ComponentThatThrows.prototype.render)
-				.to.have.been.calledOnce;
-			
-			expect(ComponentThatThrows.prototype.render)
-				.to.throw();
+				.to.have.been.calledOnce
+				.and.to.throw();
 
 			// ComponentThatRenders
 			expect(ComponentThatRenders.prototype.componentDidCatch)
 				.to.not.have.been.called;
 			
 			expect(ComponentThatRenders.prototype.render)
-				.to.have.been.calledOnce;
-
-			expect(ComponentThatRenders.prototype.render)
-				.to.not.throw();
+				.to.have.been.calledOnce
+				.and.to.not.throw();
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)

--- a/test/render.js
+++ b/test/render.js
@@ -612,10 +612,12 @@ describe('render', () => {
 	});
 
 	describe('Error Handling', () => {
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s getDerivedStateFromProps', () => {
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' getDerivedStateFromProps', () => {
+			const ERROR_MESSAGE = 'getDerivedStateFromProps error',
+				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
 				static getDerivedStateFromProps() {
-					throw new Error();
+					throw THE_ERROR;
 				}
 				componentDidCatch(error) {}
 				render(props) {
@@ -664,7 +666,7 @@ describe('render', () => {
 			// ComponentThatThrows
 			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
 				.to.have.been.calledOnce
-				.and.to.throw();
+				.and.to.throw(Error, ERROR_MESSAGE);
 
 			expect(ComponentThatThrows.prototype.componentDidCatch)
 				.to.not.have.been.called;
@@ -682,8 +684,9 @@ describe('render', () => {
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)
-				.to.have.been.calledOnce;
-			
+				.to.have.been.calledOnce
+				.and.calledWithExactly(THE_ERROR);
+
 			expect(ErrorBoundry.prototype.render)
 				.to.have.been.calledTwice;
 
@@ -695,10 +698,12 @@ describe('render', () => {
 				.to.not.have.been.called;
 		});
 		
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s componentWillMount', () => {
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' componentWillMount', () => {
+			const ERROR_MESSAGE = 'componentWillMount error',
+				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
 				componentWillMount() {
-					throw new Error();
+					throw THE_ERROR;
 				}
 				componentDidCatch(error) {}
 				render(props) {
@@ -750,7 +755,7 @@ describe('render', () => {
 
 			expect(ComponentThatThrows.prototype.componentWillMount)
 				.to.have.been.calledOnce
-				.and.to.throw();
+				.and.to.throw(Error, ERROR_MESSAGE);
 
 			expect(ComponentThatThrows.prototype.render)
 				.to.not.have.been.called;
@@ -765,7 +770,8 @@ describe('render', () => {
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)
-				.to.have.been.calledOnce;
+				.to.have.been.calledOnce
+				.and.calledWithExactly(THE_ERROR);
 			
 			expect(ErrorBoundry.prototype.render)
 				.to.have.been.calledTwice;
@@ -778,11 +784,13 @@ describe('render', () => {
 				.to.not.have.been.called;
 		});
 		
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s render', () => {
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' render', () => {
+			const ERROR_MESSAGE = 'render error',
+				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					throw new Error();
+					throw THE_ERROR;
 					return <div {...props} />; // eslint-disable-line
 				}
 			}
@@ -830,7 +838,7 @@ describe('render', () => {
 
 			expect(ComponentThatThrows.prototype.render)
 				.to.have.been.calledOnce
-				.and.to.throw();
+				.and.to.throw(Error, ERROR_MESSAGE);
 
 			// ComponentThatRenders
 			expect(ComponentThatRenders.prototype.componentDidCatch)
@@ -842,7 +850,8 @@ describe('render', () => {
 
 			// ErrorBoundry
 			expect(ErrorBoundry.prototype.componentDidCatch)
-				.to.have.been.calledOnce;
+				.to.have.been.calledOnce
+				.and.calledWithExactly(THE_ERROR);
 			
 			expect(ErrorBoundry.prototype.render)
 				.to.have.been.calledTwice;

--- a/test/render.js
+++ b/test/render.js
@@ -610,4 +610,68 @@ describe('render', () => {
 			expect(Bar).to.have.been.calledOnce.and.calledWithMatch({ count: 1 });
 		});
 	});
+
+	describe('Error Handling', () => {
+		it('should invoke componentDidCatch from an error thrown in getDerivedStateFromProps', () => {
+			const error = new Error();
+			class Test extends Component {
+				static getDerivedStateFromProps() {
+					throw error;
+				}
+				componentDidCatch(error) {}
+			}
+			spy(Test.prototype.constructor, 'getDerivedStateFromProps');
+			spy(Test.prototype, 'componentDidCatch');
+
+			render(<Test />);
+			
+			expect(Test.prototype.constructor.getDerivedStateFromProps)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
+
+			expect(Test.prototype.constructor.getDerivedStateFromProps)
+				.to.throw();
+		});
+		
+		it('should invoke componentDidCatch from an error thrown in componentWillMount', () => {
+			class Test extends Component {
+				componentWillMount() {
+					throw new Error('Error in componentWillMount() method');
+				}
+				componentDidCatch(error) {}
+			}
+			spy(Test.prototype, 'componentWillMount');
+			spy(Test.prototype, 'componentDidCatch');
+
+			render(<Test />);
+
+			expect(Test.prototype.componentWillMount)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
+
+			expect(Test.prototype.componentWillMount)
+				.to.throw();
+		});
+		
+		it('should invoke componentDidCatch from an error thrown in render', () => {
+			class Test extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					throw new Error('Error in render() method');
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			spy(Test.prototype, 'render');
+			spy(Test.prototype, 'componentDidCatch');
+
+			render(<Test />);
+
+			expect(Test.prototype.render)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
+
+			expect(Test.prototype.render)
+				.to.throw();
+		});
+	});
 });

--- a/test/render.js
+++ b/test/render.js
@@ -612,7 +612,7 @@ describe('render', () => {
 	});
 
 	describe('Error Handling', () => {
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' getDerivedStateFromProps', () => {
+		it('should invoke ErrorBoundary\'s componentDidCatch from an error thrown in ComponentThatThrows\' getDerivedStateFromProps', () => {
 			const ERROR_MESSAGE = 'getDerivedStateFromProps error',
 				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
@@ -630,7 +630,7 @@ describe('render', () => {
 					return <div {...props} />;
 				}
 			}
-			class ErrorBoundry extends Component {
+			class ErrorBoundary extends Component {
 				constructor(props) {
 					super(props);
 					this.state = { throwError: true };
@@ -647,7 +647,7 @@ describe('render', () => {
 			class App extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <ErrorBoundry />;
+					return <ErrorBoundary />;
 				}
 			}
 			
@@ -656,8 +656,8 @@ describe('render', () => {
 			spy(ComponentThatThrows.prototype, 'render');
 			spy(ComponentThatRenders.prototype, 'componentDidCatch');
 			spy(ComponentThatRenders.prototype, 'render');
-			spy(ErrorBoundry.prototype, 'componentDidCatch');
-			spy(ErrorBoundry.prototype, 'render');
+			spy(ErrorBoundary.prototype, 'componentDidCatch');
+			spy(ErrorBoundary.prototype, 'render');
 			spy(App.prototype, 'componentDidCatch');
 			spy(App.prototype, 'render');
 
@@ -682,12 +682,12 @@ describe('render', () => {
 				.to.have.been.calledOnce
 				.and.to.not.throw();
 
-			// ErrorBoundry
-			expect(ErrorBoundry.prototype.componentDidCatch)
+			// ErrorBoundary
+			expect(ErrorBoundary.prototype.componentDidCatch)
 				.to.have.been.calledOnce
 				.and.calledWithExactly(THE_ERROR);
 
-			expect(ErrorBoundry.prototype.render)
+			expect(ErrorBoundary.prototype.render)
 				.to.have.been.calledTwice;
 
 			// App
@@ -698,7 +698,7 @@ describe('render', () => {
 				.to.not.have.been.called;
 		});
 		
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' componentWillMount', () => {
+		it('should invoke ErrorBoundary\'s componentDidCatch from an error thrown in ComponentThatThrows\' componentWillMount', () => {
 			const ERROR_MESSAGE = 'componentWillMount error',
 				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
@@ -716,7 +716,7 @@ describe('render', () => {
 					return <div {...props} />;
 				}
 			}
-			class ErrorBoundry extends Component {
+			class ErrorBoundary extends Component {
 				constructor(props) {
 					super(props);
 					this.state = { throwError: true };
@@ -733,7 +733,7 @@ describe('render', () => {
 			class App extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <ErrorBoundry />;
+					return <ErrorBoundary />;
 				}
 			}
 			
@@ -742,8 +742,8 @@ describe('render', () => {
 			spy(ComponentThatThrows.prototype, 'render');
 			spy(ComponentThatRenders.prototype, 'componentDidCatch');
 			spy(ComponentThatRenders.prototype, 'render');
-			spy(ErrorBoundry.prototype, 'componentDidCatch');
-			spy(ErrorBoundry.prototype, 'render');
+			spy(ErrorBoundary.prototype, 'componentDidCatch');
+			spy(ErrorBoundary.prototype, 'render');
 			spy(App.prototype, 'componentDidCatch');
 			spy(App.prototype, 'render');
 
@@ -768,12 +768,12 @@ describe('render', () => {
 				.to.have.been.calledOnce
 				.and.to.not.throw();
 
-			// ErrorBoundry
-			expect(ErrorBoundry.prototype.componentDidCatch)
+			// ErrorBoundary
+			expect(ErrorBoundary.prototype.componentDidCatch)
 				.to.have.been.calledOnce
 				.and.calledWithExactly(THE_ERROR);
 			
-			expect(ErrorBoundry.prototype.render)
+			expect(ErrorBoundary.prototype.render)
 				.to.have.been.calledTwice;
 
 			// App
@@ -784,7 +784,7 @@ describe('render', () => {
 				.to.not.have.been.called;
 		});
 		
-		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\' render', () => {
+		it('should invoke ErrorBoundary\'s componentDidCatch from an error thrown in ComponentThatThrows\' render', () => {
 			const ERROR_MESSAGE = 'render error',
 				THE_ERROR = new Error(ERROR_MESSAGE);
 			class ComponentThatThrows extends Component {
@@ -800,7 +800,7 @@ describe('render', () => {
 					return <div {...props} />;
 				}
 			}
-			class ErrorBoundry extends Component {
+			class ErrorBoundary extends Component {
 				constructor(props) {
 					super(props);
 					this.state = { throwError: true };
@@ -817,7 +817,7 @@ describe('render', () => {
 			class App extends Component {
 				componentDidCatch(error) {}
 				render(props) {
-					return <ErrorBoundry />;
+					return <ErrorBoundary />;
 				}
 			}
 			
@@ -825,8 +825,8 @@ describe('render', () => {
 			spy(ComponentThatThrows.prototype, 'render');
 			spy(ComponentThatRenders.prototype, 'componentDidCatch');
 			spy(ComponentThatRenders.prototype, 'render');
-			spy(ErrorBoundry.prototype, 'componentDidCatch');
-			spy(ErrorBoundry.prototype, 'render');
+			spy(ErrorBoundary.prototype, 'componentDidCatch');
+			spy(ErrorBoundary.prototype, 'render');
 			spy(App.prototype, 'componentDidCatch');
 			spy(App.prototype, 'render');
 
@@ -848,12 +848,12 @@ describe('render', () => {
 				.to.have.been.calledOnce
 				.and.to.not.throw();
 
-			// ErrorBoundry
-			expect(ErrorBoundry.prototype.componentDidCatch)
+			// ErrorBoundary
+			expect(ErrorBoundary.prototype.componentDidCatch)
 				.to.have.been.calledOnce
 				.and.calledWithExactly(THE_ERROR);
 			
-			expect(ErrorBoundry.prototype.render)
+			expect(ErrorBoundary.prototype.render)
 				.to.have.been.calledTwice;
 
 			// App

--- a/test/render.js
+++ b/test/render.js
@@ -612,65 +612,259 @@ describe('render', () => {
 	});
 
 	describe('Error Handling', () => {
-		it('should invoke componentDidCatch from an error thrown in getDerivedStateFromProps', () => {
-			class Test extends Component {
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s getDerivedStateFromProps', () => {
+			class ComponentThatThrows extends Component {
 				static getDerivedStateFromProps() {
 					throw new Error();
 				}
 				componentDidCatch(error) {}
-			}
-			spy(Test.prototype.constructor, 'getDerivedStateFromProps');
-			spy(Test.prototype, 'componentDidCatch');
-
-			render(<Test />);
-			
-			expect(Test.prototype.constructor.getDerivedStateFromProps)
-				.to.have.been.calledOnce
-				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
-
-			expect(Test.prototype.constructor.getDerivedStateFromProps)
-				.to.throw();
-		});
-		
-		it('should invoke componentDidCatch from an error thrown in componentWillMount', () => {
-			class Test extends Component {
-				componentWillMount() {
-					throw new Error('Error in componentWillMount() method');
-				}
-				componentDidCatch(error) {}
-			}
-			spy(Test.prototype, 'componentWillMount');
-			spy(Test.prototype, 'componentDidCatch');
-
-			render(<Test />);
-
-			expect(Test.prototype.componentWillMount)
-				.to.have.been.calledOnce
-				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
-
-			expect(Test.prototype.componentWillMount)
-				.to.throw();
-		});
-		
-		it('should invoke componentDidCatch from an error thrown in render', () => {
-			class Test extends Component {
-				componentDidCatch(error) {}
 				render(props) {
-					throw new Error('Error in render() method');
 					return <div {...props} />; // eslint-disable-line
 				}
 			}
-			spy(Test.prototype, 'render');
-			spy(Test.prototype, 'componentDidCatch');
+			class ComponentThatRenders extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			class ErrorBoundry extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { throwError: true };
+				}
+				componentDidCatch(error) {
+					this.setState({ throwError: false });
+				}
+				render(props, state) {
+					return state.throwError
+						? <ComponentThatThrows />
+						: <ComponentThatRenders />;
+				}
+			}
+			class App extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <ErrorBoundry />;
+				}
+			}
+			
+			spy(ComponentThatThrows.prototype.constructor, 'getDerivedStateFromProps');
+			spy(ComponentThatThrows.prototype, 'componentDidCatch');
+			spy(ComponentThatThrows.prototype, 'render');
+			spy(ComponentThatRenders.prototype, 'componentDidCatch');
+			spy(ComponentThatRenders.prototype, 'render');
+			spy(ErrorBoundry.prototype, 'componentDidCatch');
+			spy(ErrorBoundry.prototype, 'render');
+			spy(App.prototype, 'componentDidCatch');
+			spy(App.prototype, 'render');
 
-			render(<Test />);
+			render(<App />);
 
-			expect(Test.prototype.render)
-				.to.have.been.calledOnce
-				.and.to.have.been.calledBefore(Test.prototype.componentDidCatch);
+			// ComponentThatThrows
+			expect(ComponentThatThrows.prototype.componentDidCatch)
+				.to.not.have.been.called;
 
-			expect(Test.prototype.render)
+			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
+				.to.have.been.calledOnce;
+			
+			expect(ComponentThatThrows.prototype.constructor.getDerivedStateFromProps)
 				.to.throw();
+
+			expect(ComponentThatThrows.prototype.render)
+				.to.not.have.been.called;
+
+			// ComponentThatRenders
+			expect(ComponentThatRenders.prototype.componentDidCatch)
+				.to.not.have.been.called;
+			
+			expect(ComponentThatRenders.prototype.render)
+				.to.have.been.calledOnce;
+
+			expect(ComponentThatRenders.prototype.render)
+				.to.not.throw();
+
+			// ErrorBoundry
+			expect(ErrorBoundry.prototype.componentDidCatch)
+				.to.have.been.calledOnce;
+			
+			expect(ErrorBoundry.prototype.render)
+				.to.have.been.calledTwice;
+
+			// App
+			expect(App.prototype.render)
+				.to.have.been.calledOnce;
+				
+			expect(App.prototype.componentDidCatch)
+				.to.not.have.been.called;
+		});
+		
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s componentWillMount', () => {
+			class ComponentThatThrows extends Component {
+				componentWillMount() {
+					throw new Error();
+				}
+				componentDidCatch(error) {}
+				render(props) {
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			class ComponentThatRenders extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			class ErrorBoundry extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { throwError: true };
+				}
+				componentDidCatch(error) {
+					this.setState({ throwError: false });
+				}
+				render(props, state) {
+					return state.throwError
+						? <ComponentThatThrows />
+						: <ComponentThatRenders />;
+				}
+			}
+			class App extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <ErrorBoundry />;
+				}
+			}
+			
+			spy(ComponentThatThrows.prototype, 'componentWillMount');
+			spy(ComponentThatThrows.prototype, 'componentDidCatch');
+			spy(ComponentThatThrows.prototype, 'render');
+			spy(ComponentThatRenders.prototype, 'componentDidCatch');
+			spy(ComponentThatRenders.prototype, 'render');
+			spy(ErrorBoundry.prototype, 'componentDidCatch');
+			spy(ErrorBoundry.prototype, 'render');
+			spy(App.prototype, 'componentDidCatch');
+			spy(App.prototype, 'render');
+
+			render(<App />);
+
+			// ComponentThatThrows
+			expect(ComponentThatThrows.prototype.componentDidCatch)
+				.to.not.have.been.called;
+
+			expect(ComponentThatThrows.prototype.componentWillMount)
+				.to.have.been.calledOnce;
+			
+			expect(ComponentThatThrows.prototype.componentWillMount)
+				.to.throw();
+
+			expect(ComponentThatThrows.prototype.render)
+				.to.not.have.been.called;
+
+			// ComponentThatRenders
+			expect(ComponentThatRenders.prototype.componentDidCatch)
+				.to.not.have.been.called;
+			
+			expect(ComponentThatRenders.prototype.render)
+				.to.have.been.calledOnce;
+
+			expect(ComponentThatRenders.prototype.render)
+				.to.not.throw();
+
+			// ErrorBoundry
+			expect(ErrorBoundry.prototype.componentDidCatch)
+				.to.have.been.calledOnce;
+			
+			expect(ErrorBoundry.prototype.render)
+				.to.have.been.calledTwice;
+
+			// App
+			expect(App.prototype.render)
+				.to.have.been.calledOnce;
+				
+			expect(App.prototype.componentDidCatch)
+				.to.not.have.been.called;
+		});
+		
+		it('should invoke ErrorBoundry\'s componentDidCatch from an error thrown in ComponentThatThrows\'s render', () => {
+			class ComponentThatThrows extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					throw new Error();
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			class ComponentThatRenders extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <div {...props} />; // eslint-disable-line
+				}
+			}
+			class ErrorBoundry extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { throwError: true };
+				}
+				componentDidCatch(error) {
+					this.setState({ throwError: false });
+				}
+				render(props, state) {
+					return state.throwError
+						? <ComponentThatThrows />
+						: <ComponentThatRenders />;
+				}
+			}
+			class App extends Component {
+				componentDidCatch(error) {}
+				render(props) {
+					return <ErrorBoundry />;
+				}
+			}
+			
+			spy(ComponentThatThrows.prototype, 'componentDidCatch');
+			spy(ComponentThatThrows.prototype, 'render');
+			spy(ComponentThatRenders.prototype, 'componentDidCatch');
+			spy(ComponentThatRenders.prototype, 'render');
+			spy(ErrorBoundry.prototype, 'componentDidCatch');
+			spy(ErrorBoundry.prototype, 'render');
+			spy(App.prototype, 'componentDidCatch');
+			spy(App.prototype, 'render');
+
+			render(<App />);
+
+			// ComponentThatThrows
+			expect(ComponentThatThrows.prototype.componentDidCatch)
+				.to.not.have.been.called;
+
+			expect(ComponentThatThrows.prototype.render)
+				.to.have.been.calledOnce;
+			
+			expect(ComponentThatThrows.prototype.render)
+				.to.throw();
+
+			// ComponentThatRenders
+			expect(ComponentThatRenders.prototype.componentDidCatch)
+				.to.not.have.been.called;
+			
+			expect(ComponentThatRenders.prototype.render)
+				.to.have.been.calledOnce;
+
+			expect(ComponentThatRenders.prototype.render)
+				.to.not.throw();
+
+			// ErrorBoundry
+			expect(ErrorBoundry.prototype.componentDidCatch)
+				.to.have.been.calledOnce;
+			
+			expect(ErrorBoundry.prototype.render)
+				.to.have.been.calledTwice;
+
+			// App
+			expect(App.prototype.render)
+				.to.have.been.calledOnce;
+				
+			expect(App.prototype.componentDidCatch)
+				.to.not.have.been.called;
 		});
 	});
 });


### PR DESCRIPTION
This does not include support for the `info` argument because `preact`'s support for `componentDidCatch()` does not pass this argument (https://github.com/developit/preact/pull/819#issue-136629967)

Also includes 3 new tests.