### PR TITLE
Release 5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact-render-to-string",
   "amdName": "preactRenderToString",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Render JSX to an HTML string, with support for Preact components.",
   "main": "dist/index.js",
   "umd:main": "dist/index.js",


### PR DESCRIPTION
- Fix `options.render` is private in core (#97, thanks @marvinhagemeister)
- Wrap arrays in `Fragment` to allow proper rendering (#96, thanks @toraora)