### PR TITLE
Join adjacent text nodes in pretty mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,16 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 			}
 		}
 		if (pretty && hasLarge) {
+			let lastOutputWasDom = s[s.length-1]=='>';
 			for (let i=pieces.length; i--; ) {
+				if (
+					i<pieces.length-1 &&
+					pieces[i][0]!='<' &&
+					((i>0 && pieces[i-1][0]!='<') || (i==0 && !lastOutputWasDom))
+				) {
+					continue;
+				}
+				
 				pieces[i] = '\n' + indentChar + indent(pieces[i], indentChar);
 			}
 		}

--- a/test/pretty.js
+++ b/test/pretty.js
@@ -96,4 +96,19 @@ describe('pretty', () => {
 			</div>
 		)).to.equal(`<div>\n\t<div>A</div>\n\t<div>B</div>\n</div>`);
 	});
+
+	it('should join adjacent text nodes', () => {
+		expect(prettyRender(
+			<div>hello{' '} <b /></div>
+		)).to.equal(`<div>\n\thello  \n\t<b></b>\n</div>`);
+		expect(prettyRender(
+			<div>hello{' '} <b />{'a'}{'b'}</div>
+		)).to.equal(`<div>\n\thello  \n\t<b></b>\n\ta\n\tb\n</div>`);
+	});
+
+	it('should join adjacent text nodeswith Fragments', () => {
+		expect(prettyRender(
+			<div><Fragment>foo</Fragment>bar{' '} <b /></div>
+		)).to.equal(`<div>\n\tfoobar  \n\t<b></b>\n</div>`);
+	});
 });


### PR DESCRIPTION
This PR joins adjacent text nodes together instead of putting them on a new line.

```jsx
// source
<div>hello{' '} <b /></div>

// before
<div>
  hello
  {' '}
   
  <b />
</div>

// after
<div>
  hello{' '} 
  <b />
</div>
```