### PR TITLE
Fix build tools deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "transpile": "microbundle src/index.js -f es,umd --target web --external preact",
     "transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
     "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",
-    "test": "eslint src test && tsc && mocha --compilers js:babel-register test/**/*.js",
+    "test": "eslint src test && tsc && mocha -r babel-core/register test/**/*.js",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "react/no-danger": 0,
       "jest/valid-expect": 0,
       "new-cap": 0
+    },
+    "settings": {
+      "react": {
+        "version": "16.8"
+      }
     }
   },
   "babel": {


### PR DESCRIPTION
This PR fixes 2 deprecation warnings:

- Mocha `compilers` options is deprecated
- Fix eslint warning `No react version specified`