### PR TITLE
Fix support for default context value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				// the context value as `this.context` just for this component.
 				let cxType = nodeName.contextType;
 				let provider = cxType && context[cxType.__c];
-				let cctx = cxType != null ? (provider ? provider.props.value : cxType._defaultValue) : context;
+				let cctx = cxType != null ? (provider ? provider.props.value : cxType.__) : context;
 
 				// stateless functional components
 				rendered = nodeName.call(vnode.__c, props, cctx);
@@ -95,7 +95,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				// class-based components
 				let cxType = nodeName.contextType;
 				let provider = cxType && context[cxType.__c];
-				let cctx = cxType != null ? (provider ? provider.props.value : cxType._defaultValue) : context;
+				let cctx = cxType != null ? (provider ? provider.props.value : cxType.__) : context;
 
 				// c = new nodeName(props, context);
 				c = vnode.__c = new nodeName(props, cctx);

--- a/test/context.js
+++ b/test/context.js
@@ -96,4 +96,21 @@ describe('context', () => {
 			<section>value is: </section>
 		`);
 	});
+
+	it('should support default context value with absent provider', () => {
+		const { Consumer } = createContext('correct');
+		let rendered = renderJsx(
+			<Consumer>
+				{(value) => (
+					<section>
+						value is: {value}
+					</section>
+				)}
+			</Consumer>
+		);
+
+		expect(rendered).to.equal(dedent`
+			<section>value is: correct</section>
+		`);
+	});
 });


### PR DESCRIPTION
Issue here was that the [mangled `_defaultValue`](https://github.com/preactjs/preact/blob/71425ff63ddd59989a7c657f659b70960d457600/mangle.json#L36) prop wasn't being used. 😱

Pretty edge case for _most_ libraries I suppose, which is why it might not have been caught yet

### Checklist

- [x] Added test