### PR TITLE
Add TypeScript definitions for JSX renderer

### DIFF
--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -1,0 +1,13 @@
+import { VNode } from 'preact';
+
+interface Options {
+  jsx?: boolean;
+  xml?: boolean;
+  functions?: boolean
+  functionNames?: boolean,
+  skipFalseAttributes?: boolean
+  pretty?: boolean | string;
+}
+
+export function render(vnode: VNode, context?: any, options?: Options):string;
+export default render;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
     "transpile": "microbundle src/index.js -f es,umd --target web --external preact",
     "transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
-    "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",
+    "copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
     "test": "eslint src test && tsc && mocha -r babel-core/register test/**/*.js",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,0 +1,13 @@
+import { VNode } from 'preact';
+
+interface Options {
+  jsx?: boolean;
+  xml?: boolean;
+  functions?: boolean
+  functionNames?: boolean,
+  skipFalseAttributes?: boolean
+  pretty?: boolean | string;
+}
+
+export function render(vnode: VNode, context?: any, options?: Options):string;
+export default render;


### PR DESCRIPTION
This PR adds the TypeScript definitions for `preact-render-to-string/jsx`.