### PR TITLE
Add submodule exports

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const snakeCaseToCamelCase = str =>
+	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
+
+const copy = name => {
+	// Copy .module.js --> .mjs for Node 13 compat.
+	const filename = name.includes('-') ? snakeCaseToCamelCase(name) : name;
+	fs.writeFileSync(
+		`${process.cwd()}/dist/${filename}.mjs`,
+		fs.readFileSync(`${process.cwd()}/dist/${filename}.module.js`)
+	);
+};
+
+copy('index');
+copy('jsx');

--- a/package.json
+++ b/package.json
@@ -7,8 +7,21 @@
   "umd:main": "dist/index.js",
   "module": "dist/index.module.js",
   "jsnext:main": "dist/index.module.js",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "browser": "./dist/index.module.js"
+    },
+    "./jsx": {
+      "require": "./dist/jsx.js",
+      "import": "./dist/jsx.mjs",
+      "browser": "./dist/jsx.module.js"
+    }
+  },
   "scripts": {
     "build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
+    "postbuild": "node ./config/node-13-exports.js",
     "transpile": "microbundle src/index.js -f es,umd --target web --external preact",
     "transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
     "copy-typescript-definition": "copyfiles -f src/*.d.ts dist",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
       "require": "./dist/jsx.js",
       "import": "./dist/jsx.mjs",
       "browser": "./dist/jsx.module.js"
-    }
+    },
+    "./package.json": "./package.json",
+    "./": "./"
   },
   "scripts": {
     "build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",


### PR DESCRIPTION
In Node v13, package exports were introduced as an official way to define sub-paths/modules within your package: https://nodejs.org/api/esm.html#esm_package_exports

Fixes #144 .