### PR TITLE
Add setState()/forceUpdate() no-op methods to prevent errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ const UNNAMED = [];
 
 const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 
+const noop = () => {};
+
 
 /** Render Preact JSX + Components to an HTML string.
  *	@name render
@@ -76,7 +78,16 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 		else {
 			let rendered;
 
-			let c = vnode.__c = { __v: vnode, context, props: vnode.props, __h: [] };
+			let c = vnode.__c = {
+				__v: vnode,
+				context,
+				props: vnode.props,
+				// silently drop state updates
+				setState: noop,
+				forceUpdate: noop,
+				// hooks
+				__h: []
+			};
 
 			// options.render
 			if (options.__r) options.__r(vnode);


### PR DESCRIPTION
This prevents hook update methods from erroring, which often looks like the following:

```
TypeError: o.__c.setState is not a function
    at QueryData.o.__c.o.__ [as forceUpdate
```

This still ensures state mutations have no effect during SSR, but allows the following code to execute without causing an exception after rendering has occurred and `pending` resolves:

```js
import { useState, useMemo } from 'preact/hooks';
function Resolve({ promise }) {
  const [value, setValue] = useState(undefined);
  const pending = useMemo(() => promise.then(setValue), [promise]);
  return value;
}
```