### PR TITLE
Override default void elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const SHALLOW = { shallow: true };
 // components without names, kept as a hash for later comparison to return consistent UnnamedComponentXX names.
 const UNNAMED = [];
 
-const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
+const HTML_VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 
 const noop = () => {};
 
@@ -235,7 +235,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 	s = `<${nodeName}${s}>`;
 	if (String(nodeName).match(/[\s\n\\/='"\0<>]/)) throw new Error(`${nodeName} is not a valid HTML tag name in ${s}`);
 
-	let isVoid = String(nodeName).match(VOID_ELEMENTS) || (opts.voidElements && String(nodeName).match(opts.voidElements));
+	let isVoid = String(nodeName).match(opts.voidElements || HTML_VOID_ELEMENTS);
 	if (isVoid) s = s.replace(/>$/, ' />');
 
 	let pieces = [];
@@ -337,5 +337,6 @@ export {
 	renderToString as render,
 	renderToString as renderToStaticMarkup,
 	renderToString,
-	shallowRender
+	shallowRender,
+	HTML_VOID_ELEMENTS
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import renderToString, { render, shallowRender, renderToStaticMarkup, renderToString as _renderToString } from '../src';
+import renderToString, { render, shallowRender, renderToStaticMarkup, renderToString as _renderToString, HTML_VOID_ELEMENTS } from '../src';
 import { expect } from 'chai';
 
 describe('render-to-string', () => {
@@ -24,6 +24,10 @@ describe('render-to-string', () => {
 
 		it('exposes shallowRender as a named export', () => {
 			expect(shallowRender).to.be.a('function');
+		});
+
+		it('exposes HTML_VOID_ELEMENTS as a named export', () => {
+			expect(HTML_VOID_ELEMENTS).to.be.a('RegExp');
 		});
 	});
 });

--- a/test/render.js
+++ b/test/render.js
@@ -208,6 +208,13 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		it('does not close default void elements when defining custom void elements', () => {
+			let rendered = render(<item><link>https://preactjs.com</link><hello-world /></item>, null, { voidElements: /^hello-world$/ }),
+				expected = `<item><link>https://preactjs.com</link><hello-world /></item>`;
+
+			expect(rendered).to.equal(expected);
+		});
+
 		it('should serialize object styles', () => {
 			let rendered = render(<div style={{ color: 'red', border: 'none' }} />),
 				expected = `<div style="color: red; border: none;"></div>`;


### PR DESCRIPTION
When working with xml, it is undesirable to have the default html void elements closed (e.g. `link`). See #53
The `voidElements` option added in #156 is additive to the default elements.

This PR makes defining a `voidElements` option become the exclusive void elements.  It also exposes the default html void elements as a named export if you want to add on to it.

Technically a breaking change, so open to feedback on how to handle.