### PR TITLE
[bugfix] do not close void elements with a closing tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,8 +236,6 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 	if (String(nodeName).match(/[\s\n\\/='"\0<>]/)) throw new Error(`${nodeName} is not a valid HTML tag name in ${s}`);
 
 	let isVoid = String(nodeName).match(VOID_ELEMENTS) || (opts.voidElements && String(nodeName).match(opts.voidElements));
-	if (isVoid) s = s.replace(/>$/, ' />');
-
 	let pieces = [];
 
 	let children;
@@ -297,7 +295,10 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 		return s.substring(0, s.length-1) + ' />';
 	}
 
-	if (!isVoid) {
+	if (isVoid && !children) {
+		s = s.replace(/>$/, ' />');
+	}
+	else {
 		if (pretty && ~s.indexOf('\n')) s += '\n';
 		s += `</${nodeName}>`;
 	}

--- a/test/render.js
+++ b/test/render.js
@@ -202,8 +202,8 @@ describe('render', () => {
 		});
 
 		it('does not close void elements with closing tags', () => {
-			let rendered = render(<input><p>Hello World</p></input>),
-				expected = `<input /><p>Hello World</p>`;
+			let rendered = render(<link>http://preactjs.com</link>),
+				expected = `<link>http://preactjs.com</link>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
If an element that is typically a void element is being used as a standard element with children, don't self close it.
The existing test for this was not doing what its description said.  This is required for better xml support. See #53
