### PR TITLE
Optimize HTML entity encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
       "react/jsx-no-bind": 0,
       "react/no-danger": 0,
       "jest/valid-expect": 0,
-      "new-cap": 0,
-      "no-fallthrough": 1
+      "new-cap": 0
     },
     "settings": {
       "react": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "react/jsx-no-bind": 0,
       "react/no-danger": 0,
       "jest/valid-expect": 0,
-      "new-cap": 0
+      "new-cap": 0,
+      "no-fallthrough": 1
     },
     "settings": {
       "react": {

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,7 @@
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
 export function encodeEntities(s) {
+	if (typeof s !== 'string') s = String(s);
 	let out = '';
 	for (let i=0; i<s.length; i++) {
 		let ch = s[i];

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,21 @@
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
-export let encodeEntities = s => String(s)
-	.replace(/&/g, '&amp;')
-	.replace(/</g, '&lt;')
-	.replace(/>/g, '&gt;')
-	.replace(/"/g, '&quot;');
+export function encodeEntities(s) {
+	let out = '';
+	for (let i=0; i<s.length; i++) {
+		let ch = s[i];
+		switch (ch) {
+			case '<': ch = '&lt;';
+			case '>': ch = '&gt;';
+			case '"': ch = '&quot;';
+			case '&': ch = '&amp;';
+		}
+		out += ch;
+	}
+	return out;
+}
+
 
 export let indent = (s, char) => String(s).replace(/(\n+)/g, '$1' + (char || '\t'));
 

--- a/src/util.js
+++ b/src/util.js
@@ -6,12 +6,12 @@ export function encodeEntities(s) {
 	for (let i=0; i<s.length; i++) {
 		let ch = s[i];
 		switch (ch) {
-			case '<': ch = '&lt;';
-			case '>': ch = '&gt;';
-			case '"': ch = '&quot;';
-			case '&': ch = '&amp;';
+			case '<': out += '&lt;'; break;
+			case '>': out += '&gt;'; break;
+			case '"': out += '&quot;'; break;
+			case '&': out += '&amp;'; break;
+			default: out += ch;
 		}
-		out += ch;
 	}
 	return out;
 }


### PR DESCRIPTION
See benchmarks:
https://esbench.com/bench/5f88af6cb4632100a7dcd414

`Scan (str) [3]` is this revised implementation, which is 50% faster than the previous implementation (`replace`).