### PR TITLE
Prevent to self-close if dangerouslySetInnerHTML set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -351,13 +351,13 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 		}
 	}
 
-	if (pieces.length) {
+	if (pieces.length || html) {
 		s += pieces.join('');
 	} else if (opts && opts.xml) {
 		return s.substring(0, s.length - 1) + ' />';
 	}
 
-	if (isVoid && !children) {
+	if (isVoid && !children && !html) {
 		s = s.replace(/>$/, ' />');
 	} else {
 		if (pretty && ~s.indexOf('\n')) s += '\n';

--- a/test/render.js
+++ b/test/render.js
@@ -228,6 +228,15 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		it('should not self-close void elements if it has dangerouslySetInnerHTML prop', () => {
+			let rendered = render(
+					<link dangerouslySetInnerHTML={{ __html: '<foo>' }} />
+				),
+				expected = `<link><foo></link>`;
+
+			expect(rendered).to.equal(expected);
+		});
+
 		it('should serialize object styles', () => {
 			let rendered = render(<div style={{ color: 'red', border: 'none' }} />),
 				expected = `<div style="color: red; border: none;"></div>`;
@@ -812,6 +821,15 @@ describe('render', () => {
 			expect(renderXml(<div />)).to.equal(`<div />`);
 			expect(renderXml(<a />)).to.equal(`<a />`);
 			expect(renderXml(<a>b</a>)).to.equal(`<a>b</a>`);
+		});
+
+		it('should not self-close if it has dangerouslySetInnerHTML prop', () => {
+			expect(
+				renderXml(<a dangerouslySetInnerHTML={{ __html: 'b' }} />)
+			).to.equal(`<a>b</a>`);
+			expect(
+				renderXml(<a dangerouslySetInnerHTML={{ __html: '<b />' }} />)
+			).to.equal(`<a><b /></a>`);
 		});
 
 		it('should render boolean attributes with named values', () => {


### PR DESCRIPTION
This change prevents to self-close if the element has `dangerouslySetInnerHTML` prop. This is required for better xml support.

Currently behavior:
```
import { h } from 'preact'
import renderToString from 'preact-render-to-string'

console.log(renderToString(<a dangerouslySetInnerHTML={{ __html: '<b />' }}></a>, undefined, { xml: true }))
// <a><b / />

console.log(renderToString(<link dangerouslySetInnerHTML={{ __html: '<foo />' }}></link>))
// <link><foo / />
```