### PR TITLE
Fix options.diffed and options._commit never being called

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6024,9 +6024,9 @@
       }
     },
     "preact": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.2.1.tgz",
-      "integrity": "sha512-BUNvmQcVtNElku7mYHexIiM5JlGNSW2BY9O2t9xk1NqA43O8wbE0cah6PAlvT7PBHvyDRJ5TAj5Fewdi9DqLoQ==",
+      "version": "10.5.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.7.tgz",
+      "integrity": "sha512-4oEpz75t/0UNcwmcsjk+BIcDdk68oao+7kxcpc1hQPNs2Oo3ZL9xFz8UBf350mxk/VEdD41L5b4l2dE3Ug3RYg==",
       "dev": true
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"microbundle": "^0.6.0",
 		"mocha": "^5.2.0",
 		"npm-merge-driver-install": "^1.1.1",
-		"preact": "^10.0.4",
+		"preact": "^10.5.7",
 		"prettier": "^2.1.2",
 		"sinon": "^1.17.5",
 		"sinon-chai": "^2.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,17 @@ renderToString.render = renderToString;
  */
 let shallowRender = (vnode, context) => renderToString(vnode, context, SHALLOW);
 
+const EMPTY_ARR = [];
+function renderToString(vnode, context, opts) {
+	const res = _renderToString(vnode, context, opts);
+	// options._commit, we don't schedule any effects in this library right now,
+	// so we can pass an empty queue to this hook.
+	if (options.__c) options.__c(vnode, EMPTY_ARR);
+	return res;
+}
+
 /** The default export is an alias of `render()`. */
-function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
+function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 	if (vnode == null || typeof vnode === 'boolean') {
 		return '';
 	}
@@ -77,7 +86,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 			for (let i = 0; i < children.length; i++) {
 				rendered +=
 					(i > 0 && pretty ? '\n' : '') +
-					renderToString(
+					_renderToString(
 						children[i],
 						context,
 						opts,
@@ -173,7 +182,8 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				context = assign(assign({}, context), c.getChildContext());
 			}
 
-			return renderToString(
+			if (options.diffed) options.diffed(vnode);
+			return _renderToString(
 				rendered,
 				context,
 				opts,
@@ -313,7 +323,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 							: nodeName === 'foreignObject'
 							? false
 							: isSvgMode,
-					ret = renderToString(
+					ret = _renderToString(
 						child,
 						context,
 						opts,

--- a/test/render.js
+++ b/test/render.js
@@ -1049,7 +1049,7 @@ describe('render', () => {
 		});
 	});
 
-	it('should invoke options._render and options._diff', () => {
+	it('should invoke option hooks', () => {
 		const calls = [];
 		// _diff
 		const oldDiff = options.__b;
@@ -1062,6 +1062,17 @@ describe('render', () => {
 		options.__r = (...args) => {
 			calls.push(['_render', args]);
 			if (oldRender) oldRender(...args);
+		};
+		const oldDiffed = options.diffed;
+		options.diffed = (...args) => {
+			calls.push(['diffed', args]);
+			if (oldDiffed) oldDiffed(...args);
+		};
+		// _commit
+		const oldCommit = options.__c;
+		options.__c = (...args) => {
+			calls.push(['_commit', args]);
+			if (oldCommit) oldCommit(...args);
 		};
 
 		function Component1({ children }) {
@@ -1080,11 +1091,14 @@ describe('render', () => {
 		expect(calls).to.deep.equal([
 			['_diff', [vnode1]],
 			['_render', [vnode1]],
+			['diffed', [vnode1]],
 			['_diff', [vnode2]],
-			['_render', [vnode2]]
+			['_render', [vnode2]],
+			['diffed', [vnode2]],
+			['_commit', [vnode1, []]]
 		]);
 
-		expect(calls.length).to.equal(4);
+		expect(calls.length).to.equal(7);
 
 		options.__b = oldDiff;
 		options.__r = oldRender;


### PR DESCRIPTION
We never called `options.diffed` and `options._commit` during SSR. Looks like we forgot to add those.

Resolves a part of the issue mentioned at https://github.com/preactjs/preact/issues/2574