### PR TITLE
Perf: Improve HTML entity escaping

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,21 +1,17 @@
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
+const HTML_ENTITY_REG = /[&<>"]/g;
+const tagsToReplace = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;'
+};
+const replaceTag = (tag) => tagsToReplace[tag] || tag;
 export function encodeEntities(s) {
 	if (typeof s !== 'string') s = String(s);
-	let out = '';
-	for (let i = 0; i < s.length; i++) {
-		let ch = s[i];
-		// prettier-ignore
-		switch (ch) {
-			case '<': out += '&lt;'; break;
-			case '>': out += '&gt;'; break;
-			case '"': out += '&quot;'; break;
-			case '&': out += '&amp;'; break;
-			default: out += ch;
-		}
-	}
-	return out;
+	return s.replace(HTML_ENTITY_REG, replaceTag);
 }
 
 export let indent = (s, char) =>


### PR DESCRIPTION
This change significantly speeds up entity ecoding making it 170 ops/sec faster than before. Benchmark: https://github.com/marko-js/isomorphic-ui-benchmarks

Machine: Macbook Air M1
Before: `851 ops/sec`
After: `1,027 ops/sec`

Fixes: #180