### PR TITLE
Revert back to old commonjs behaviour.

### DIFF
--- a/config/node-commonjs.js
+++ b/config/node-commonjs.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+// This file will only export default exports in commonjs bundles
+// instead of guarding them behind a `.default` property.
+
+const filePath = (file) => path.join(process.cwd(), 'dist', file);
+
+// Main entry
+fs.copyFileSync(filePath('index.js'), filePath('commonjs.js'));
+fs.copyFileSync(filePath('index.js.map'), filePath('commonjs.js.map'));
+
+const source = `module.exports = require('./commonjs').default;`;
+fs.writeFileSync(filePath('index.js'), source, 'utf-8');
+
+// JSX entry
+fs.copyFileSync(filePath('jsx.js'), filePath('jsx-entry.js'));
+fs.copyFileSync(filePath('jsx.js.map'), filePath('jsx-entry.js.map'));
+
+const sourceJsx = `module.exports = require('./jsx-entry').default;`;
+fs.writeFileSync(filePath('jsx.js'), sourceJsx, 'utf-8');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	},
 	"scripts": {
 		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
-		"postbuild": "node ./config/node-13-exports.js",
+		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js",
 		"transpile": "microbundle src/index.js -f es,umd --target web --external preact",
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",


### PR DESCRIPTION
A recent dependency update changed the exported values in our `commonjs` entries by exposing both the `default` export and `named` exports. This commit ensures that we're always using the default export and ignore any named ones.

Regardless of whether the new behaviour is the preferred one, we should not do such breaking changes in a patch release.

Fixes #182 