### PR TITLE
Performance: Memoize entity encoding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ const UNNAMED = [];
 
 const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 
+const UNSAFE_NAME = /[\s\n\\/='"\0<>]/;
+
 const noop = () => {};
 
 /** Render Preact JSX + Components to an HTML string.
@@ -291,12 +293,12 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 	}
 
 	s = `<${nodeName}${s}>`;
-	if (String(nodeName).match(/[\s\n\\/='"\0<>]/))
+	if (UNSAFE_NAME.test(String(nodeName)))
 		throw new Error(`${nodeName} is not a valid HTML tag name in ${s}`);
 
 	let isVoid =
-		String(nodeName).match(VOID_ELEMENTS) ||
-		(opts.voidElements && String(nodeName).match(opts.voidElements));
+		VOID_ELEMENTS.test(String(nodeName)) ||
+		(opts.voidElements && opts.voidElements.test(String(nodeName)));
 	let pieces = [];
 
 	let children;

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,20 @@
+/**
+ * @template T
+ * @param {T} fn
+ * @returns {T}
+ */
+function memoize(fn) {
+	const cache = new Map();
+	return (arg) => {
+		let res = cache.get(arg);
+		if (!res) {
+			res = fn(arg);
+			cache.set(arg, res);
+		}
+		return res;
+	};
+}
+
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
@@ -9,10 +26,15 @@ const tagsToReplace = {
 	'"': '&quot;'
 };
 const replaceTag = (tag) => tagsToReplace[tag] || tag;
-export function encodeEntities(s) {
+
+/**
+ * @param {any} s
+ * @returns {string}
+ */
+export const encodeEntities = memoize((s) => {
 	if (typeof s !== 'string') s = String(s);
 	return s.replace(HTML_ENTITY_REG, replaceTag);
-}
+});
 
 export let indent = (s, char) =>
 	String(s).replace(/(\n+)/g, '$1' + (char || '\t'));


### PR DESCRIPTION
A good chunk of serverside rendering is spent escaping strings. There is a high likelyness, that we'll see the same strings over and over again. By memoizing those computations we get a nice speedup. A tiny bit more (at least in benchmarks) can be achieved by hoisting out regex creation.

| Benchmark | before (ops/sec) | after (ops/sec) |
|---|---|---|
| Text | 260.183 | **401.336** |
| SearchResults | 637.04 | **730.82** |
