### PR TITLE
Revert "Memoize entity encoding"

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,20 +1,3 @@
-/**
- * @template T
- * @param {T} fn
- * @returns {T}
- */
-function memoize(fn) {
-	const cache = new Map();
-	return (arg) => {
-		let res = cache.get(arg);
-		if (!res) {
-			res = fn(arg);
-			cache.set(arg, res);
-		}
-		return res;
-	};
-}
-
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
@@ -26,15 +9,10 @@ const tagsToReplace = {
 	'"': '&quot;'
 };
 const replaceTag = (tag) => tagsToReplace[tag] || tag;
-
-/**
- * @param {any} s
- * @returns {string}
- */
-export const encodeEntities = memoize((s) => {
+export function encodeEntities(s) {
 	if (typeof s !== 'string') s = String(s);
 	return s.replace(HTML_ENTITY_REG, replaceTag);
-});
+}
 
 export let indent = (s, char) =>
 	String(s).replace(/(\n+)/g, '$1' + (char || '\t'));


### PR DESCRIPTION
This reverts commit f5bae9ea9c3e30793e83a3f50a0172bae614ae2c.

Because we cannot forsee the length and amount of strings we need to be more careful about keeping them around as memory consumption can grow unbounded. In the future we should check if we can use a limited cache, only cache attributes or something else. WeakMaps unfortunately won't help as they cannot be used with primitives as cache key.

Got notified privately that a production site ran into a memory leak and we definitely don't want that. Let this be a lesson for myself to be sceptical of memoization, despite it being an easy way to improve benchmark scores!