### PR TITLE
Benchmark runner updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /npm-debug.log
 .DS_Store
 /src/preact-render-to-string-tests.d.ts
+/benchmarks/.v8.modern.js

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,19 +1,21 @@
 import { h } from 'preact';
 import Suite from 'benchmarkjs-pretty';
+import renderToStringBaseline from './lib/render-to-string';
 import renderToString from '../src/index';
 import TextApp from './text';
 // import StackApp from './stack';
 import { App as IsomorphicSearchResults } from './isomorphic-ui-search-results';
 
-new Suite('Bench')
-	.add('Text', () => {
-		return renderToString(<TextApp />);
-	})
-	.add('SearchResults', () => {
-		return renderToString(<IsomorphicSearchResults />);
-	})
+function suite(name, Root) {
+	return new Suite(name)
+		.add('baseline', () => renderToStringBaseline(<Root />))
+		.add('current', () => renderToString(<Root />))
+		.run();
+}
+
+(async () => {
+	await suite('Text', TextApp);
+	await suite('SearchResults', IsomorphicSearchResults);
 	// TODO: Enable this once we switched away from recursion
-	// .add('Stack Depth', () => {
-	// 	return renderToString(<StackApp />);
-	// })
-	.run();
+	// await suite('Stack Depth', StackApp);
+})();

--- a/benchmarks/lib/benchmark-lite.js
+++ b/benchmarks/lib/benchmark-lite.js
@@ -1,0 +1,60 @@
+export default class Suite {
+	constructor(name, { iterations = 10, timeLimit = 5000 } = {}) {
+		this.name = name;
+		this.iterations = iterations;
+		this.timeLimit = timeLimit;
+		this.tests = [];
+	}
+	add(name, executor) {
+		this.tests.push({ name, executor });
+		return this;
+	}
+	run() {
+		console.log(`  ${this.name}:`);
+		const results = [];
+		let fastest = 0;
+		for (const test of this.tests) {
+			for (let i = 0; i < 5; i++) test.executor(i);
+			const result = this.runOne(test);
+			if (result.hz > fastest) fastest = result.hz;
+			results.push({ ...test, ...result });
+		}
+		const winners = results.filter((r) => r.hz === fastest).map((r) => r.name);
+		console.log(`  Fastest: \x1b[32m${winners}\x1b[39m\n`);
+		return this;
+	}
+	runOne({ name, executor }) {
+		const { iterations, timeLimit } = this;
+		let count = 5;
+		let now = performance.now(),
+			start = now,
+			prev = now;
+		const times = [];
+		do {
+			for (let i = iterations; i--; ) executor(++count);
+			prev = now;
+			now = performance.now();
+			times.push((now - prev) / iterations);
+		} while (now - start < timeLimit);
+		const elapsed = now - start;
+		const hz = Math.round((count / elapsed) * 1000);
+		const average = toFixed(elapsed / count);
+		const middle = Math.floor(times.length / 2);
+		const middle2 = Math.ceil(times.length / 2);
+		times.sort((a, b) => a - b);
+		const median = toFixed((times[middle] + times[middle2]) / 2);
+		const hzStr = hz.toLocaleString();
+		const averageStr = average.toLocaleString();
+		const n = times.length;
+		const stdev = Math.sqrt(
+			times.reduce((c, t) => c + (t - average) ** 2, 0) / (n - 1)
+		);
+		const p95 = toFixed((1.96 * stdev) / Math.sqrt(n));
+		console.log(
+			`    \x1b[36m${name}:\x1b[0m ${hzStr}/s, average: ${averageStr}ms ±${p95} (median: ${median}ms)`
+		);
+		return { elapsed, hz, average, median };
+	}
+}
+
+const toFixed = (v) => ((v * 100) | 0) / 100;

--- a/benchmarks/lib/render-to-string.js
+++ b/benchmarks/lib/render-to-string.js
@@ -1,0 +1,255 @@
+/* eslint-disable */
+// preact-render-to-string@5.1.16
+import { options as e, createElement as t, Fragment as r } from 'preact';
+var n = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i,
+	o = /[&<>"]/g,
+	i = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' },
+	a = function (e) {
+		return i[e] || e;
+	};
+function l(e) {
+	return 'string' != typeof e && (e = String(e)), e.replace(o, a);
+}
+var s = function (e, t) {
+		return String(e).replace(/(\n+)/g, '$1' + (t || '\t'));
+	},
+	f = function (e, t, r) {
+		return (
+			String(e).length > (t || 40) ||
+			(!r && -1 !== String(e).indexOf('\n')) ||
+			-1 !== String(e).indexOf('<')
+		);
+	},
+	u = {};
+function c(e) {
+	var t = '';
+	for (var r in e) {
+		var o = e[r];
+		null != o &&
+			'' !== o &&
+			(t && (t += ' '),
+			(t +=
+				'-' == r[0]
+					? r
+					: u[r] || (u[r] = r.replace(/([A-Z])/g, '-$1').toLowerCase())),
+			(t += ': '),
+			(t += o),
+			'number' == typeof o && !1 === n.test(r) && (t += 'px'),
+			(t += ';'));
+	}
+	return t || void 0;
+}
+function p(e, t) {
+	for (var r in t) e[r] = t[r];
+	return e;
+}
+function _(e, t) {
+	return (
+		Array.isArray(t) ? t.reduce(_, e) : null != t && !1 !== t && e.push(t), e
+	);
+}
+var v = { shallow: !0 },
+	d = [],
+	g = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/,
+	h = /[\s\n\\/='"\0<>]/,
+	m = function () {};
+b.render = b;
+var x = function (e, t) {
+		return b(e, t, v);
+	},
+	y = [];
+function b(t, r, n) {
+	var o = S(t, r, n);
+	return e.__c && e.__c(t, y), o;
+}
+function S(n, o, i, a, u, v) {
+	if (null == n || 'boolean' == typeof n) return '';
+	Array.isArray(n) && (n = t(r, null, n));
+	var x = n.type,
+		y = n.props,
+		b = !1;
+	o = o || {};
+	var w,
+		k = (i = i || {}).pretty,
+		O = k && 'string' == typeof k ? k : '\t';
+	if ('object' != typeof n && !x) return l(n);
+	if ('function' == typeof x) {
+		if (((b = !0), !i.shallow || (!a && !1 !== i.renderRootComponent))) {
+			if (x === r) {
+				var C = '',
+					A = [];
+				_(A, n.props.children);
+				for (var H = 0; H < A.length; H++)
+					C +=
+						(H > 0 && k ? '\n' : '') +
+						S(A[H], o, i, !1 !== i.shallowHighOrder, u, v);
+				return C;
+			}
+			var j,
+				F = (n.__c = {
+					__v: n,
+					context: o,
+					props: n.props,
+					setState: m,
+					forceUpdate: m,
+					__h: []
+				});
+			if (
+				(e.__b && e.__b(n),
+				e.__r && e.__r(n),
+				x.prototype && 'function' == typeof x.prototype.render)
+			) {
+				var M = x.contextType,
+					T = M && o[M.__c],
+					$ = null != M ? (T ? T.props.value : M.__) : o;
+				((F = n.__c = new x(y, $)).__v = n),
+					(F._dirty = F.__d = !0),
+					(F.props = y),
+					null == F.state && (F.state = {}),
+					null == F._nextState &&
+						null == F.__s &&
+						(F._nextState = F.__s = F.state),
+					(F.context = $),
+					x.getDerivedStateFromProps
+						? (F.state = p(
+								p({}, F.state),
+								x.getDerivedStateFromProps(F.props, F.state)
+						  ))
+						: F.componentWillMount &&
+						  (F.componentWillMount(),
+						  (F.state =
+								F._nextState !== F.state
+									? F._nextState
+									: F.__s !== F.state
+									? F.__s
+									: F.state)),
+					(j = F.render(F.props, F.state, F.context));
+			} else {
+				var L = x.contextType,
+					E = L && o[L.__c];
+				j = x.call(n.__c, y, null != L ? (E ? E.props.value : L.__) : o);
+			}
+			return (
+				F.getChildContext && (o = p(p({}, o), F.getChildContext())),
+				e.diffed && e.diffed(n),
+				S(j, o, i, !1 !== i.shallowHighOrder, u, v)
+			);
+		}
+		x =
+			(w = x).displayName ||
+			(w !== Function && w.name) ||
+			(function (e) {
+				var t = (Function.prototype.toString
+					.call(e)
+					.match(/^\s*function\s+([^( ]+)/) || '')[1];
+				if (!t) {
+					for (var r = -1, n = d.length; n--; )
+						if (d[n] === e) {
+							r = n;
+							break;
+						}
+					r < 0 && (r = d.push(e) - 1), (t = 'UnnamedComponent' + r);
+				}
+				return t;
+			})(w);
+	}
+	var D,
+		N,
+		P = '';
+	if (y) {
+		var R = Object.keys(y);
+		i && !0 === i.sortAttributes && R.sort();
+		for (var U = 0; U < R.length; U++) {
+			var W = R[U],
+				q = y[W];
+			if ('children' !== W) {
+				if (
+					!W.match(/[\s\n\\/='"\0<>]/) &&
+					((i && i.allAttributes) ||
+						('key' !== W &&
+							'ref' !== W &&
+							'__self' !== W &&
+							'__source' !== W &&
+							'defaultValue' !== W))
+				) {
+					if ('className' === W) {
+						if (y.class) continue;
+						W = 'class';
+					} else
+						u &&
+							W.match(/^xlink:?./) &&
+							(W = W.toLowerCase().replace(/^xlink:?/, 'xlink:'));
+					if ('htmlFor' === W) {
+						if (y.for) continue;
+						W = 'for';
+					}
+					'style' === W && q && 'object' == typeof q && (q = c(q)),
+						'a' === W[0] &&
+							'r' === W[1] &&
+							'boolean' == typeof q &&
+							(q = String(q));
+					var z = i.attributeHook && i.attributeHook(W, q, o, i, b);
+					if (z || '' === z) P += z;
+					else if ('dangerouslySetInnerHTML' === W) N = q && q.__html;
+					else if ('textarea' === x && 'value' === W) D = q;
+					else if ((q || 0 === q || '' === q) && 'function' != typeof q) {
+						if (!((!0 !== q && '' !== q) || ((q = W), i && i.xml))) {
+							P += ' ' + W;
+							continue;
+						}
+						if ('value' === W) {
+							if ('select' === x) {
+								v = q;
+								continue;
+							}
+							'option' === x && v == q && (P += ' selected');
+						}
+						P += ' ' + W + '="' + l(q) + '"';
+					}
+				}
+			} else D = q;
+		}
+	}
+	if (k) {
+		var I = P.replace(/^\n\s*/, ' ');
+		I === P || ~I.indexOf('\n')
+			? k && ~P.indexOf('\n') && (P += '\n')
+			: (P = I);
+	}
+	if (((P = '<' + x + P + '>'), h.test(String(x))))
+		throw new Error(x + ' is not a valid HTML tag name in ' + P);
+	var V,
+		Z = g.test(String(x)) || (i.voidElements && i.voidElements.test(String(x))),
+		B = [];
+	if (N) k && f(N) && (N = '\n' + O + s(N, O)), (P += N);
+	else if (null != D && _((V = []), D).length) {
+		for (var G = k && ~P.indexOf('\n'), J = !1, K = 0; K < V.length; K++) {
+			var Q = V[K];
+			if (null != Q && !1 !== Q) {
+				var X = S(Q, o, i, !0, 'svg' === x || ('foreignObject' !== x && u), v);
+				if ((k && !G && f(X) && (G = !0), X))
+					if (k) {
+						var Y = X.length > 0 && '<' != X[0];
+						J && Y ? (B[B.length - 1] += X) : B.push(X), (J = Y);
+					} else B.push(X);
+			}
+		}
+		if (k && G) for (var ee = B.length; ee--; ) B[ee] = '\n' + O + s(B[ee], O);
+	}
+	if (B.length || N) P += B.join('');
+	else if (i && i.xml) return P.substring(0, P.length - 1) + ' />';
+	return (
+		!Z || V || N
+			? (k && ~P.indexOf('\n') && (P += '\n'), (P += '</' + x + '>'))
+			: (P = P.replace(/>$/, ' />')),
+		P
+	);
+}
+b.shallowRender = x;
+export default b;
+export {
+	b as render,
+	b as renderToStaticMarkup,
+	b as renderToString,
+	x as shallowRender
+};

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
 		"./": "./"
 	},
 	"scripts": {
-		"bench": "node -r @babel/register benchmarks index.js",
+		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",
 		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
 		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js",
 		"transpile": "microbundle src/index.js -f es,umd --target web --external preact",
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
-		"test": "eslint src test && tsc && npm run test:mocha",
+		"test": "eslint src test && tsc && npm run test:mocha && npm run bench",
 		"test:mocha": "mocha -r @babel/register -r test/setup.js test/**/*.test.js",
 		"format": "prettier src/**/*.{d.ts,js} test/**/*.js --write",
 		"prepublishOnly": "npm run build",
@@ -65,17 +65,28 @@
 		}
 	},
 	"babel": {
-		"presets": [
-			"@babel/preset-env"
-		],
-		"plugins": [
-			[
-				"@babel/plugin-transform-react-jsx",
-				{
-					"pragma": "h"
-				}
-			]
-		]
+		"env": {
+			"test": {
+				"presets": [
+					[
+						"@babel/preset-env",
+						{
+							"targets": {
+								"node": true
+							}
+						}
+					]
+				],
+				"plugins": [
+					[
+						"@babel/plugin-transform-react-jsx",
+						{
+							"pragma": "h"
+						}
+					]
+				]
+			}
+		}
 	},
 	"author": "Jason Miller <jason@developit.ca>",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	},
 	"scripts": {
 		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",
+		"bench:v8": "BABEL_ENV=test microbundle benchmarks/index.js -f modern --alias benchmarkjs-pretty=benchmarks/lib/benchmark-lite.js --external none --target node --no-compress --no-sourcemap --raw -o benchmarks/.v8.js && v8 --module benchmarks/.v8.modern.js",
 		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
 		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js",
 		"transpile": "microbundle src/index.js -f es,umd --target web --external preact",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
 		"test": "eslint src test && tsc && npm run test:mocha && npm run bench",
-		"test:mocha": "mocha -r @babel/register -r test/setup.js test/**/*.test.js",
+		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/**/*.test.js",
 		"format": "prettier src/**/*.{d.ts,js} test/**/*.js --write",
 		"prepublishOnly": "npm run build",
 		"release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"


### PR DESCRIPTION
This updates the benchmarks to run against a previous known good state (preact-render-to-string@5.1.16), which makes them resilient to machine & time differences (similar to our tach setups).

It also adds a second `d8`-based benchmark runner based on the same code, using a crappy version of benchmarkjs I wrote.