### PR TITLE
Skip effects during RTS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const SHALLOW = { shallow: true };
 
 // components without names, kept as a hash for later comparison to return consistent UnnamedComponentXX names.
 const UNNAMED = [];
+const _skipEffects = '__s';
 
 const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 
@@ -47,10 +48,15 @@ const EMPTY_ARR = [];
 function renderToString(vnode, context, opts) {
 	context = context || {};
 	opts = opts || {};
+
+	const previousSkipEffects = options[_skipEffects];
+	options[_skipEffects] = true;
+
 	const res = _renderToString(vnode, context, opts);
 	// options._commit, we don't schedule any effects in this library right now,
 	// so we can pass an empty queue to this hook.
 	if (options.__c) options.__c(vnode, EMPTY_ARR);
+	options[_skipEffects] = previousSkipEffects;
 	return res;
 }
 


### PR DESCRIPTION
This skips effects during `renderToString` just like React, as this function runs synchronously anyway and isn't subject to effectful rerenders.

Fixes: https://github.com/preactjs/preact-render-to-string/issues/191