### PR TITLE
Add encodeEntities fast path for inputs that don't need anything replaced

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,14 @@
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
 
-export function encodeEntities(s) {
-	return String(s)
+const ENCODED_ENTITIES = /[&<>"]/;
+
+export function encodeEntities(input) {
+	const s = String(input);
+	if (!ENCODED_ENTITIES.test(s)) {
+		return s;
+	}
+	return s
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;')


### PR DESCRIPTION
This pull request attempts to optimize util.js's `encodeEntities` function. This happens by skipping the `.replace(...)` chain for inputs that contain no characters that should be replaced.

The benchmarks seem get a boost from this (Node v14.16.0, Linux, x86), especially the SearchResults one. Here are the `npm run bench` results before this change:

```
Text:
baseline x 80.883 ops/sec ±1.16 (67 runs sampled)
current x 94.593 ops/sec ±2.36 (73 runs sampled)

SearchResults:
baseline x 404.532 ops/sec ±2.42 (79 runs sampled)
current x 448.104 ops/sec ±2.61 (83 runs sampled)
```

And after this change: 

```
Text:
baseline x 83.055 ops/sec ±1.54 (68 runs sampled)
current x 103.134 ops/sec ±1.95 (74 runs sampled)

SearchResults:
baseline x 453.03 ops/sec ±2.13 (84 runs sampled)
current x 648.997 ops/sec ±2.88 (83 runs sampled)
```