### PR TITLE
Fix: serialize defaultValue as value attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,12 +240,13 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				(name === 'key' ||
 					name === 'ref' ||
 					name === '__self' ||
-					name === '__source' ||
-					name === 'defaultValue')
+					name === '__source')
 			)
 				continue;
 
-			if (name === 'className') {
+			if (name === 'defaultValue') {
+				name = 'value';
+			} else if (name === 'className') {
 				if (props.class) continue;
 				name = 'class';
 			} else if (isSvgMode && name.match(/^xlink:?./)) {

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -82,9 +82,9 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
-		it('should omit defaultValue attribute', () => {
+		it('should serialize defaultValue props to the value attribute', () => {
 			let rendered = render(<div defaultValue="test" />),
-				expected = `<div></div>`;
+				expected = `<div value="test"></div>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
h/t @washingtonsteven who found this

This is sortof a follow-up to the patch from #163 - we shouldn't serialize `defaultValue` as `defaultValue`, but instead omitting it we should serialize to the `value` attribute (which is effectively the same as the `defaultValue` property).