### PR TITLE
fix: On empty className w/ compat, class attr will no longer be duplicated

### DIFF
--- a/.changeset/fifty-rings-jog.md
+++ b/.changeset/fifty-rings-jog.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+On empty className w/ compat, class attribute will no longer be duplicated

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external preact && microbundle dist/jsx.js -o dist/jsx.js -f cjs --external preact",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
 		"test": "eslint src test && tsc && npm run test:mocha && npm run bench",
-		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/**/*.test.js",
+		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/**/[!compat]*.test.js && npm run test:mocha:compat",
+		"test:mocha:compat": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/compat.test.js",
 		"format": "prettier src/**/*.{d.ts,js} test/**/*.js --write",
 		"prepublishOnly": "npm run build",
 		"release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const SHALLOW = { shallow: true };
 // components without names, kept as a hash for later comparison to return consistent UnnamedComponentXX names.
 const UNNAMED = [];
 
-const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
+const VOID_ELEMENTS =
+	/^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 
 const UNSAFE_NAME = /[\s\n\\/='"\0<>]/;
 
@@ -247,7 +248,7 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 			if (name === 'defaultValue') {
 				name = 'value';
 			} else if (name === 'className') {
-				if (props.class) continue;
+				if (typeof props.class !== 'undefined') continue;
 				name = 'class';
 			} else if (isSvgMode && name.match(/^xlink:?./)) {
 				name = name.toLowerCase().replace(/^xlink:?/, 'xlink:');

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -1,0 +1,12 @@
+import { render } from '../src';
+import { createElement } from 'preact/compat';
+import { expect } from 'chai';
+
+describe('compat', () => {
+	it('should not duplicate class attribute when className is empty', async () => {
+		let rendered = render(createElement('div', { className: '' }));
+		let expected = `<div class></div>`;
+
+		expect(rendered).to.equal(expected);
+	});
+});


### PR DESCRIPTION
Fixes #208

Empty `props.class` wouldn't be truthy, resulting in `class` being added to the element twice as outlined in the attached issue.

The added test might be a bit overkill, but it seems Mocha has no support for test isolation. Importing `preact/compat` (even in other suites) would throw off one of the existing tests, so I just run the compat suite subsequently. Let me know if there's a better way to go about this.