### PR TITLE
Update Travis CI badge to GitHub Actions [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # preact-render-to-string
 
 [![NPM](http://img.shields.io/npm/v/preact-render-to-string.svg)](https://www.npmjs.com/package/preact-render-to-string)
-[![travis-ci](https://travis-ci.org/preactjs/preact-render-to-string.svg)](https://travis-ci.org/preactjs/preact-render-to-string)
+[![Build status](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml/badge.svg)](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml)
 
 Render JSX and [Preact] components to an HTML string.
 


### PR DESCRIPTION
This project hasn't been using Travis CI since it switched to GitHub Actions in
https://github.com/preactjs/preact-render-to-string/pull/179 (Feb 2021), but the
README still shows the old Travis CI badge which currently shows build status as
"failing".