### PR TITLE
Implement hook state settling

### DIFF
--- a/.changeset/chilly-ligers-agree.md
+++ b/.changeset/chilly-ligers-agree.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": minor
+---
+
+Implement hook state settling. Setting hook state during the execution of a function component (eg: in `useMemo`) will now re-render the component and use the final result. Previously, these updates were dropped.


### PR DESCRIPTION
This implements hooks state "settling", where a function component that invokes setState/forceUpdate during rendering is re-invoked up to 25 times or until it stops invalidating during invocation.

The implementation here is for Preact 10, and will need to be updated to use Internal.flags in Preact 11 (however RTS is moved to core in 11).

Fixes #218.