### PR TITLE
fix: Serialize defaultChecked as checked attr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,10 +263,12 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 
 			if (name === 'defaultValue') {
 				name = 'value';
+			} else if (name === 'defaultChecked') {
+				name = 'checked';
 			} else if (name === 'className') {
 				if (typeof props.class !== 'undefined') continue;
 				name = 'class';
-			} else if (isSvgMode && name.match(/^xlink:?./)) {
+			} else if (isSvgMode && /^xlink:?./.test(name)) {
 				name = name.toLowerCase().replace(/^xlink:?/, 'xlink:');
 			}
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -95,6 +95,13 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		it('should serialize defaultChecked prop to the checked attribute', () => {
+			let rendered = render(<input type="checkbox" defaultChecked />),
+				expected = `<input type="checkbox" checked />`;
+
+			expect(rendered).to.equal(expected);
+		});
+
 		it('should include boolean aria-* attributes', () => {
 			let rendered = render(<div aria-hidden aria-whatever={false} />),
 				expected = `<div aria-hidden="true" aria-whatever="false"></div>`;


### PR DESCRIPTION
Closes #223

Not sure if there are any other `defaultX` props to be concerned with (my memory and MDN are failing me). I think every other check / replace method would be a fair bit slower, so I imagine while limited to these two (`defaultValue` and `defaultChecked`) this approach is better? LMK!