### PR TITLE
[perf] Improve string encoding performance by ~50%

### DIFF
--- a/.changeset/orange-poems-learn.md
+++ b/.changeset/orange-poems-learn.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+Improve string encoding performance by ~50%

--- a/src/util.js
+++ b/src/util.js
@@ -4,13 +4,15 @@ export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine
 const ENCODED_ENTITIES = /[&<>"]/;
 
 export function encodeEntities(str) {
-	if (ENCODED_ENTITIES.test(s) === false) return s;
+	// Skip all work for strings with no entities needing encoding:
+	if (ENCODED_ENTITIES.test(str) === false) return str;
+
 	let start = 0,
 		i = 0,
 		out = '',
 		ch = '';
 	for (; i<str.length; i++) {
-		switch(str.charCodeAt(i)) {
+		switch (str.charCodeAt(i)) {
 			case 60: ch = '&lt;'; break;
 			case 62: ch = '&gt;'; break;
 			case 34: ch = '&quot;'; break;

--- a/src/util.js
+++ b/src/util.js
@@ -3,16 +3,25 @@ export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine
 
 const ENCODED_ENTITIES = /[&<>"]/;
 
-export function encodeEntities(input) {
-	const s = String(input);
-	if (!ENCODED_ENTITIES.test(s)) {
-		return s;
+export function encodeEntities(str) {
+	if (ENCODED_ENTITIES.test(s) === false) return s;
+	let start = 0,
+		i = 0,
+		out = '',
+		ch = '';
+	for (; i<str.length; i++) {
+		switch(str.charCodeAt(i)) {
+			case 60: ch = '&lt;'; break;
+			case 62: ch = '&gt;'; break;
+			case 34: ch = '&quot;'; break;
+			case 38: ch = '&amp;'; break;
+			default: continue;
+		}
+		if (i > start) out += str.slice(start, i);
+		out += ch;
+		start = i + 1;
 	}
-	return s
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+	return out + str.slice(start, i);
 }
 
 export let indent = (s, char) =>

--- a/src/util.js
+++ b/src/util.js
@@ -4,13 +4,18 @@ export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine
 const ENCODED_ENTITIES = /[&<>"]/;
 
 export function encodeEntities(str) {
+	// Ensure we're always parsing and returning a string:
+	str += '';
+
 	// Skip all work for strings with no entities needing encoding:
 	if (ENCODED_ENTITIES.test(str) === false) return str;
 
-	let start = 0,
+	let last = 0,
 		i = 0,
 		out = '',
 		ch = '';
+
+	// Seek forward in str until the next entity char:
 	for (; i<str.length; i++) {
 		switch (str.charCodeAt(i)) {
 			case 60: ch = '&lt;'; break;
@@ -19,11 +24,13 @@ export function encodeEntities(str) {
 			case 38: ch = '&amp;'; break;
 			default: continue;
 		}
-		if (i > start) out += str.slice(start, i);
+		// Append skipped/buffered characters and the encoded entity:
+		if (i > last) out += str.slice(last, i);
 		out += ch;
-		start = i + 1;
+		// Start the next seek/buffer after the entity's offset:
+		last = i + 1;
 	}
-	return out + str.slice(start, i);
+	return out + str.slice(last, i);
 }
 
 export let indent = (s, char) =>


### PR DESCRIPTION
Entity encoding is a large portion of time spent, since we encode all attribute values and text nodes.
This switches encoding from multiple regular expressions to a linear forward scan.

In [the benchmark below](https://esbench.com/bench/5f88af6cb4632100a7dcd414), the previous algorithm is the second bar ("replace"), and the new algorithm is the last bar ("scanSegments 2"):

<img width="756" alt="Screen Shot 2022-07-20 at 9 46 45 PM" src="https://user-images.githubusercontent.com/105127/180112013-224aea7e-41a1-4c4e-a512-672eee45474a.png">

**Note:** This doesn't show up in our two benchmarks here, because there are no entities present in the text or attributes in those benchmarks.