### PR TITLE
[perf] split out pretty and create hot paths

### DIFF
--- a/.changeset/silly-masks-jump.md
+++ b/.changeset/silly-masks-jump.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Split up hot paths and make separate path for opts.pretty

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "5.1.19",
+	"version": "5.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-render-to-string",
-			"version": "5.1.19",
+			"version": "5.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"pretty-format": "^3.8.0"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
 			"browser": "./dist/jsx.module.js",
 			"require": "./dist/jsx.js"
 		},
-		"./package.json": "./package.json",
-		"./": "./"
+		"./package.json": "./package.json"
 	},
 	"scripts": {
 		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",

--- a/src/util.js
+++ b/src/util.js
@@ -75,8 +75,7 @@ export function styleObjToCss(s) {
  * @private
  */
 export function assign(obj, props) {
-	for (let i in props) obj[i] = props[i];
-	return obj;
+	return Object.assign(obj, props);
 }
 
 /**


### PR DESCRIPTION
This PR aims to create as many hot paths as possible, we went from being slower than react 18 string rendering to

## FROM

```
Running "search-results"...

Running benchmark "preact"...
preact x 1,003 ops/sec ±1.53% (88 runs sampled)

Running benchmark "react"...
react x 1,127 ops/sec ±6.13% (76 runs sampled)

--------------
Running "color-picker"...

Running benchmark "preact"...
preact x 5,513 ops/sec ±0.29% (93 runs sampled)

Running benchmark "react"...
react x 5,829 ops/sec ±8.04% (79 runs sampled)
--------------
```

## TO

```
Running "search-results"...

Running benchmark "preact"...
preact x 1,437 ops/sec ±1.56% (93 runs sampled)

Running benchmark "react"...
react x 1,235 ops/sec ±5.94% (82 runs sampled)

--------------

Running "color-picker"...

Running benchmark "preact"...
preact x 7,862 ops/sec ±0.31% (92 runs sampled)

Running benchmark "react"...
react x 6,083 ops/sec ±8.30% (78 runs sampled)

--------------
```