### PR TITLE
Add HTML comments support

### DIFF
--- a/.changeset/late-zoos-swim.md
+++ b/.changeset/late-zoos-swim.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Prevent rendering invalid HTML for "comment" elements

--- a/src/index.js
+++ b/src/index.js
@@ -389,6 +389,10 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 		return startElement + ' />';
 	}
 
+	if (type.startsWith('!--')) {
+		return s + '<' + type + '>';
+	}
+
 	return s + '</' + type + '>';
 }
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -301,6 +301,11 @@ describe('render', () => {
 				`<svg><image xlink:href="#"></image><foreignObject><div xlinkHref="#"></div></foreignObject><g><image xlink:href="#"></image></g></svg>`
 			);
 		});
+
+		it('should not render invalid HTML comments', () => {
+			let rendered = render(h('!--foo--', null, 'test'));
+			expect(rendered).to.equal(`<!--foo-->test<!--foo-->`);
+		});
 	});
 
 	describe('Functional Components', () => {


### PR DESCRIPTION
Preact doesn't really support HTML comments, but it is possible to (mis)use it to generate HTML comments anyway, by creating an element with a name that starts with `!--` and ends with `--`, making sure it does not have any attributes. For example, this is being used in Fresh (see denoland/fresh#838) to enable islands.
The closing tag of such a "comment" tag however generates invalid HTML, i.e.

```javascript
h("!--foo--", null, children)
```
will generate
```html
<!--foo--> ... </!--foo-->
```
The closing tag: `</!--` is invalid HTML and might make it hard for some clients to deal with. Chrome/Firefox have a long track record of magically fixing broken HTML and they turn this into:
```html
<!--!--foo---->
```
If you plan to programmatically read data from comments (which is a perfectly valid thing to do), you will get some unexpected results as your data will now be prefixed with `!--` and suffixed with `--`.

This change adds "support" for HTML comments by at least not generating invalid HTML.

I'm not 100% sure what kind of change this is, I would think a patch since it's quite the edge case and it fixes rendering invalid HTML in this edge case. But please do correct me if I'm wrong.