### PR TITLE
Use named exports in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,18 @@
 [![NPM](http://img.shields.io/npm/v/preact-render-to-string.svg)](https://www.npmjs.com/package/preact-render-to-string)
 [![Build status](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml/badge.svg)](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml)
 
-Render JSX and [Preact] components to an HTML string.
+Render JSX and [Preact](https://github.com/developit/preact) components to an HTML string.
 
 Works in Node & the browser, making it useful for universal/isomorphic rendering.
 
 \>\> **[Cute Fox-Related Demo](http://codepen.io/developit/pen/dYZqjE?editors=001)** _(@ CodePen)_ <<
 
-
 ---
-
 
 ### Render JSX/VDOM to HTML
 
 ```js
-import render from 'preact-render-to-string';
+import { render } from 'preact-render-to-string';
 import { h } from 'preact';
 /** @jsx h */
 
@@ -27,24 +25,23 @@ console.log(html);
 // <div class="foo">content</div>
 ```
 
-
 ### Render Preact Components to HTML
 
 ```js
-import render from 'preact-render-to-string';
+import { render } from 'preact-render-to-string';
 import { h, Component } from 'preact';
 /** @jsx h */
 
 // Classical components work
 class Fox extends Component {
 	render({ name }) {
-		return <span class="fox">{ name }</span>;
+		return <span class="fox">{name}</span>;
 	}
 }
 
 // ... and so do pure functional components:
 const Box = ({ type, children }) => (
-	<div class={`box box-${type}`}>{ children }</div>
+	<div class={`box box-${type}`}>{children}</div>
 );
 
 let html = render(
@@ -57,22 +54,20 @@ console.log(html);
 // <div class="box box-open"><span class="fox">Finn</span></div>
 ```
 
-
 ---
-
 
 ### Render JSX / Preact / Whatever via Express!
 
 ```js
 import express from 'express';
 import { h } from 'preact';
-import render from 'preact-render-to-string';
+import { render } from 'preact-render-to-string';
 /** @jsx h */
 
 // silly example component:
 const Fox = ({ name }) => (
 	<div class="fox">
-		<h5>{ name }</h5>
+		<h5>{name}</h5>
 		<p>This page is all about {name}.</p>
 	</div>
 );
@@ -89,14 +84,8 @@ app.get('/:fox', (req, res) => {
 });
 ```
 
-
 ---
-
 
 ### License
 
-[MIT]
-
-
-[Preact]: https://github.com/developit/preact
-[MIT]: http://choosealicense.com/licenses/mit/
+[MIT](http://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM](http://img.shields.io/npm/v/preact-render-to-string.svg)](https://www.npmjs.com/package/preact-render-to-string)
 [![Build status](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml/badge.svg)](https://github.com/preactjs/preact-render-to-string/actions/workflows/ci.yml)
 
-Render JSX and [Preact](https://github.com/developit/preact) components to an HTML string.
+Render JSX and [Preact](https://github.com/preactjs/preact) components to an HTML string.
 
 Works in Node & the browser, making it useful for universal/isomorphic rendering.
 


### PR DESCRIPTION
Some `README` changes:

- Use named exports instead of default export. We might want to drop the default export at some point
- rest is prettier changes when saving the file