### PR TITLE
support rendering text signals

### DIFF
--- a/.changeset/proud-rice-pull.md
+++ b/.changeset/proud-rice-pull.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+support rendering text signals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "5.2.4",
+	"version": "5.2.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "5.2.4",
+			"name": "preact-render-to-string",
+			"version": "5.2.6",
 			"license": "MIT",
 			"dependencies": {
 				"pretty-format": "^3.8.0"
@@ -16,6 +17,7 @@
 				"@babel/register": "^7.12.10",
 				"@changesets/changelog-github": "^0.4.1",
 				"@changesets/cli": "^2.18.0",
+				"@preact/signals": "^1.1.0",
 				"benchmarkjs-pretty": "^2.0.1",
 				"chai": "^4.2.0",
 				"copyfiles": "^2.4.1",
@@ -1930,6 +1932,32 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@preact/signals": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.1.2.tgz",
+			"integrity": "sha512-MLNNrICSllHBhpXBvXbl7K5L1HmIjuTzgBw+zdODqjM/cLGPXdYiAWt4lqXlrxNavYdoU4eljb+TLE+DRL+6yw==",
+			"dev": true,
+			"dependencies": {
+				"@preact/signals-core": "^1.2.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.2.tgz",
+			"integrity": "sha512-z3/bCj7rRA21RJb4FeJ4guCrD1CQbaURHkCTunUWQpxUMAFOPXCD8tSFqERyGrrcSb4T3Hrmdc1OAl0LXBHwiw==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/@rollup/plugin-alias": {
@@ -15104,6 +15132,21 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@preact/signals": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.1.2.tgz",
+			"integrity": "sha512-MLNNrICSllHBhpXBvXbl7K5L1HmIjuTzgBw+zdODqjM/cLGPXdYiAWt4lqXlrxNavYdoU4eljb+TLE+DRL+6yw==",
+			"dev": true,
+			"requires": {
+				"@preact/signals-core": "^1.2.2"
+			}
+		},
+		"@preact/signals-core": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.2.tgz",
+			"integrity": "sha512-z3/bCj7rRA21RJb4FeJ4guCrD1CQbaURHkCTunUWQpxUMAFOPXCD8tSFqERyGrrcSb4T3Hrmdc1OAl0LXBHwiw==",
+			"dev": true
 		},
 		"@rollup/plugin-alias": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"@babel/register": "^7.12.10",
 		"@changesets/cli": "^2.18.0",
 		"@changesets/changelog-github": "^0.4.1",
+		"@preact/signals": "^1.1.0",
 		"benchmarkjs-pretty": "^2.0.1",
 		"chai": "^4.2.0",
 		"copyfiles": "^2.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import {
 	createComponent,
 	UNSAFE_NAME,
 	XLINK,
-	VOID_ELEMENTS
+	VOID_ELEMENTS,
+	isSignalLike
 } from './util';
 import { options, h, Fragment } from 'preact';
 import { _renderToStringPretty } from './pretty';
@@ -261,7 +262,7 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 	}
 
 	// VNodes have {constructor:undefined} to prevent JSON injection:
-	if (vnode.constructor !== undefined) return '';
+	if (vnode.constructor !== undefined && !isSignalLike(vnode)) return '';
 
 	vnode[PARENT] = parent;
 	if (options[DIFF]) options[DIFF](vnode);

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -8,7 +8,8 @@ import {
 	getContext,
 	UNSAFE_NAME,
 	XLINK,
-	VOID_ELEMENTS
+	VOID_ELEMENTS,
+	isSignalLike
 } from './util';
 import { options, Fragment } from 'preact';
 
@@ -55,7 +56,7 @@ export function _renderToStringPretty(
 	}
 
 	// VNodes have {constructor:undefined} to prevent JSON injection:
-	if (vnode.constructor !== undefined) return '';
+	if (vnode.constructor !== undefined && !isSignalLike(vnode)) return '';
 
 	let nodeName = vnode.type,
 		props = vnode.props,

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,15 @@ export const XLINK = /^xlink:?./;
 
 const ENCODED_ENTITIES = /["&<]/;
 
+export function isSignalLike(x) {
+	return (
+		x !== null &&
+		typeof x === 'object' &&
+		typeof x.peek === 'function' &&
+		'value' in x
+	);
+}
+
 export function encodeEntities(str) {
 	// Ensure we're always parsing and returning a string:
 	str += '';

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -10,6 +10,7 @@ import {
 } from 'preact/hooks';
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
+import { useSignal } from '@preact/signals';
 
 describe('render', () => {
 	describe('Basic JSX', () => {
@@ -1292,6 +1293,17 @@ describe('render', () => {
 			}
 
 			expect(render(<App />)).to.equal('<div><p>P481</p><p>P476951</p></div>');
+		});
+	});
+
+	describe('signals', () => {
+		it('should render text signals', () => {
+			function App() {
+				const text = useSignal('hello world');
+				return <p>{text}</p>;
+			}
+
+			expect(render(<App />)).to.equal('<p>hello world</p>');
 		});
 	});
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -10,7 +10,6 @@ import {
 } from 'preact/hooks';
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
-import { useSignal } from '@preact/signals';
 
 describe('render', () => {
 	describe('Basic JSX', () => {
@@ -1293,17 +1292,6 @@ describe('render', () => {
 			}
 
 			expect(render(<App />)).to.equal('<div><p>P481</p><p>P476951</p></div>');
-		});
-	});
-
-	describe('signals', () => {
-		it('should render text signals', () => {
-			function App() {
-				const text = useSignal('hello world');
-				return <p>{text}</p>;
-			}
-
-			expect(render(<App />)).to.equal('<p>hello world</p>');
 		});
 	});
 });

--- a/test/signals.test.js
+++ b/test/signals.test.js
@@ -1,0 +1,24 @@
+import { useSignal } from '@preact/signals';
+import { expect } from 'chai';
+import { h } from 'preact';
+import { render } from '../src';
+
+describe('signals', () => {
+	it('should render text signals', () => {
+		function App() {
+			const text = useSignal('hello world');
+			return <p>{text}</p>;
+		}
+
+		expect(render(<App />)).to.equal('<p>hello world</p>');
+	});
+
+	it('should render prop signals', () => {
+		function App() {
+			const className = useSignal('test');
+			return <p className={className}>hello world</p>;
+		}
+
+		expect(render(<App />)).to.equal('<p class="test">hello world</p>');
+	});
+});


### PR DESCRIPTION
This adds support for rendering textual signals, do note that currently the `render.test.js` test suite has stopped running. No clue when this started happening will figure out in a bit.

EDIT: test stop starting at https://github.com/preactjs/preact-render-to-string/pull/257/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35