### PR TITLE
fix the regex breaking the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external preact && microbundle dist/jsx.js -o dist/jsx.js -f cjs --external preact",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
 		"test": "eslint src test && tsc && npm run test:mocha && npm run test:mocha:compat && npm run test:mocha:debug && npm run bench",
-		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/**/[!compat][!debug]*.test.js",
-		"test:mocha:compat": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/compat.test.js 'test/compat-*.test.js'",
-		"test:mocha:debug": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/debug.test.js 'test/debug-*.test.js'",
+		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/*.test.js",
+		"test:mocha:compat": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/compat.test.js 'test/compat/index.test.js'",
+		"test:mocha:debug": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/debug.test.js 'test/debug/index.test.js'",
 		"format": "prettier src/**/*.{d.ts,js} test/**/*.js --write",
 		"prepublishOnly": "npm run build",
 		"release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"

--- a/test/compat/index.test.js
+++ b/test/compat/index.test.js
@@ -1,4 +1,4 @@
-import { render } from '../src';
+import { render } from '../../src';
 import { createElement } from 'preact/compat';
 import { expect } from 'chai';
 

--- a/test/debug/index.test.js
+++ b/test/debug/index.test.js
@@ -1,5 +1,5 @@
 import 'preact/debug';
-import { render } from '../src';
+import { render } from '../../src';
 import { h } from 'preact';
 import { expect } from 'chai';
 


### PR DESCRIPTION
The glob pattern introduced in https://github.com/preactjs/preact-render-to-string/pull/257/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35 broke the tests running correctly, this moves stuff to their own dir and tweaks test running