### PR TITLE
Remove trailing space for void elements

### DIFF
--- a/.changeset/gentle-trains-attack.md
+++ b/.changeset/gentle-trains-attack.md
@@ -2,4 +2,6 @@
 'preact-render-to-string': major
 ---
 
-Remove trailing space for void_elements
+Remove trailing space for void_elements, this could fail some test_assertions as
+`<img />` will become `<img/>`, the other `VOID_ELEMENTS` this will be applied for
+can be found [here](https://github.com/preactjs/preact-render-to-string/blob/remove-trailing-space/src/index.js#L368-L385)

--- a/.changeset/gentle-trains-attack.md
+++ b/.changeset/gentle-trains-attack.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': major
+---
+
+Remove trailing space for void_elements

--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,7 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 
 	// Emit self-closing tag for empty void elements:
 	if (!html && SELF_CLOSING.has(type)) {
-		return s + ' />';
+		return s + '/>';
 	}
 
 	return s + '>' + html + '</' + type + '>';

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -116,7 +116,7 @@ describe('render', () => {
 
 		it('should serialize defaultChecked prop to the checked attribute', () => {
 			let rendered = render(<input type="checkbox" defaultChecked />),
-				expected = `<input type="checkbox" checked />`;
+				expected = `<input type="checkbox" checked/>`;
 
 			expect(rendered).to.equal(expected);
 		});
@@ -240,7 +240,7 @@ describe('render', () => {
 						<wbr />
 					</div>
 				),
-				expected = `<div><input type="text" /><wbr /></div>`;
+				expected = `<div><input type="text"/><wbr/></div>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
Marked as major in case people rely on this for tests

Fixes #279 