### PR TITLE
Bring back missing exports from 5.x

### DIFF
--- a/.changeset/curvy-rings-invent.md
+++ b/.changeset/curvy-rings-invent.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Bring back exports from 5.x to make migration easier

--- a/config/node-commonjs.js
+++ b/config/node-commonjs.js
@@ -1,11 +1,23 @@
 const fs = require('fs');
 const path = require('path');
-const assert = require('assert/strict');
 
 // This file will only export default exports in commonjs bundles
 // instead of guarding them behind a `.default` property.
 
 const filePath = (file) => path.join(process.cwd(), 'dist', file);
+
+// Main entry
+fs.copyFileSync(filePath('index.js'), filePath('commonjs.js'));
+fs.copyFileSync(filePath('index.js.map'), filePath('commonjs.js.map'));
+
+const source = [
+	`const mod = require('./commonjs');`,
+	`mod.default.renderToStaticMarkup = mod.default;`,
+	`mod.default.renderToString = mod.default;`,
+	`mod.default.render = mod.default;`,
+	`module.exports = mod.default;`
+].join('\n');
+fs.writeFileSync(filePath('index.js'), source, 'utf-8');
 
 // JSX entry
 fs.copyFileSync(filePath('jsx.js'), filePath('jsx-entry.js'));
@@ -18,15 +30,3 @@ const sourceJsx = [
 	`module.exports = entry.default;`
 ].join('\n');
 fs.writeFileSync(filePath('jsx.js'), sourceJsx, 'utf-8');
-
-// Verify CJS entries
-const main = require(filePath('index.js'));
-assert(typeof main === 'function', 'Default export is a function');
-
-const jsx = require(filePath('jsx.js'));
-assert(typeof jsx === 'function', 'Default export is a function');
-assert(typeof jsx.render === 'function', 'render entry is a function');
-assert(
-	typeof jsx.shallowRender === 'function',
-	'shallowRender entry is a function'
-);

--- a/config/node-verify-exports.js
+++ b/config/node-verify-exports.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const assert = require('assert/strict');
+
+const filePath = (file) => path.join(process.cwd(), 'dist', file);
+
+// Main CJS
+const mainCjs = require(filePath('index.js'));
+assert(typeof mainCjs === 'function');
+assert(typeof mainCjs.renderToString === 'function');
+assert(typeof mainCjs.renderToStaticMarkup === 'function');
+assert(typeof mainCjs.render === 'function');
+
+// Main ESM
+(async () => {
+	const mainESM = await import(filePath('index.mjs'));
+	assert(typeof mainESM.default === 'function');
+	assert(typeof mainESM.renderToString === 'function');
+	assert(typeof mainESM.renderToStaticMarkup === 'function');
+	assert(typeof mainESM.render === 'function');
+})();
+
+// JSX CJS
+const jsxCjs = require(filePath('jsx.js'));
+assert(typeof jsxCjs === 'function');
+assert(typeof jsxCjs.render === 'function');
+assert(typeof jsxCjs.shallowRender === 'function');
+
+// JSX ESM
+(async () => {
+	const jsxESM = await import(filePath('jsx.mjs'));
+	assert(typeof jsxESM.default === 'function');
+	assert(typeof jsxESM.render === 'function');
+	assert(typeof jsxESM.shallowRender === 'function');
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-render-to-string",
-			"version": "6.0.0",
+			"version": "6.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"pretty-format": "^3.8.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",
 		"bench:v8": "BABEL_ENV=test microbundle benchmarks/index.js -f modern --alias benchmarkjs-pretty=benchmarks/lib/benchmark-lite.js --external none --target node --no-compress --no-sourcemap --raw -o benchmarks/.v8.mjs && v8 --module benchmarks/.v8.mjs",
 		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
-		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js",
+		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js && node ./config/node-verify-exports.js",
 		"transpile": "microbundle src/index.js -f es,cjs,umd --target web --external preact",
 		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external preact && microbundle dist/jsx.js -o dist/jsx.js -f cjs --external preact",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,7 @@
 import { VNode } from 'preact';
 
 export default function renderToString(vnode: VNode, context?: any): string;
+
+export function render(vnode: VNode, context?: any): string;
+export function renderToString(vnode: VNode, context?: any): string;
+export function renderToStaticMarkup(vnode: VNode, context?: any): string;

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ let beforeDiff, afterDiff, renderHook, ummountHook;
  * @param {Object} [context={}] Initial root context object
  * @returns {string} serialized HTML
  */
-export default function renderToString(vnode, context) {
+export function renderToString(vnode, context) {
 	// Performance optimization: `renderToString` is synchronous and we
 	// therefore don't execute any effects. To do that we pass an empty
 	// array to `options._commit` (`__c`). But we can go one step further
@@ -379,3 +379,7 @@ const SELF_CLOSING = new Set([
 	'track',
 	'wbr'
 ]);
+
+export default renderToString;
+export const render = renderToString;
+export const renderToStaticMarkup = renderToString;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -15,7 +15,10 @@ export default function renderToStringPretty(
 	context?: any,
 	options?: Options
 ): string;
+export function render(vnode: VNode, context?: any, options?: Options): string;
 
-export function shallowRender(vnode: VNode, context?: any): string;
-
-export default render;
+export function shallowRender(
+	vnode: VNode,
+	context?: any,
+	options?: Options
+): string;


### PR DESCRIPTION
We removed a couple named exports in `6.0.0`, but it turns out that this clashes with a couple of libraries in the Preact ecosystem that we use. This PR brings back all the missing exports, with the exception of `shallowRender` which was moved to `preact-render-to-string/jsx` in `6.0.0`.

On top of that I added a quick script to verify that all of them work to prevent such issues in the future.

Fixes #290 