### PR TITLE
Fix to add type file for jsx.js

### DIFF
--- a/.changeset/mean-coins-move.md
+++ b/.changeset/mean-coins-move.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix to add type file for jsx.js

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"src",
 		"dist",
 		"jsx.js",
+		"jsx.d.ts",
 		"typings.json"
 	],
 	"eslintConfig": {


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact-render-to-string/issues/297

When I build the following code with the tsc command, I get an error message.
```
import { shallowRender } from 'preact-render-to-string/jsx';
import {h} from "preact";

const Sample = () => <div>sample</div>

shallowRender(<Sample />);
```
The error message is as follows

```
❯ tsc -p tsconfig.json --strict
src/index.tsx:1:31 - error TS7016: Could not find a declaration file for module 'preact-render-to-string/jsx'. '/Users/shinyama-k/preact-render/node_modules/preact-render-to-string/jsx.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/preact-render-to-string` if it exists or add a new declaration (.d.ts) file containing `declare module 'preact-render-to-string/jsx';`

1 import { shallowRender } from 'preact-render-to-string/jsx';

```

To fix this problem, added configuration to include the jsx.d.ts file in tarball of the npm package.