### PR TITLE
Add support for linking to Deno projects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { encodeEntities, styleObjToCss, UNSAFE_NAME, XLINK } from './util';
+import { encodeEntities, styleObjToCss, UNSAFE_NAME, XLINK } from './util.js';
 import { options, h, Fragment } from 'preact';
 import {
 	CHILDREN,
@@ -12,7 +12,7 @@ import {
 	RENDER,
 	SKIP_EFFECTS,
 	VNODE
-} from './constants';
+} from './constants.js';
 
 /** @typedef {import('preact').VNode} VNode */
 

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -1,6 +1,6 @@
-import './polyfills';
-import renderToString from './pretty';
-import { indent, encodeEntities } from './util';
+import './polyfills.js';
+import renderToString from './pretty.js';
+import { indent, encodeEntities } from './util.js';
 import prettyFormat from 'pretty-format';
 
 /** @typedef {import('preact').VNode} VNode */

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -8,8 +8,8 @@ import {
 	UNSAFE_NAME,
 	XLINK,
 	VOID_ELEMENTS
-} from './util';
-import { COMMIT, DIFF, DIFFED, RENDER, SKIP_EFFECTS } from './constants';
+} from './util.js';
+import { COMMIT, DIFF, DIFFED, RENDER, SKIP_EFFECTS } from './constants.js';
 import { options, Fragment } from 'preact';
 
 /** @typedef {import('preact').VNode} VNode */
@@ -133,7 +133,6 @@ function _renderToStringPretty(
 				!nodeName.prototype ||
 				typeof nodeName.prototype.render !== 'function'
 			) {
-
 				// If a hook invokes setState() to invalidate the component during rendering,
 				// re-render it up to 25 times to allow "settling" of memoized states.
 				// Note:
@@ -149,7 +148,6 @@ function _renderToStringPretty(
 					rendered = nodeName.call(vnode.__c, props, cctx);
 				}
 			} else {
-
 				// c = new nodeName(props, context);
 				c = vnode.__c = new nodeName(props, cctx);
 				c.__v = vnode;

--- a/test/compat/index.test.js
+++ b/test/compat/index.test.js
@@ -1,4 +1,4 @@
-import render from '../../src';
+import render from '../../src/index.js';
 import { createElement } from 'preact/compat';
 import { expect } from 'chai';
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,7 +1,7 @@
-import render from '../src/jsx';
+import render from '../src/jsx.js';
 import { h, createContext, Component } from 'preact';
 import { expect } from 'chai';
-import { dedent } from './utils';
+import { dedent } from './utils.js';
 
 describe('context', () => {
 	let renderJsx = (jsx, opts) => render(jsx, null, opts).replace(/ {2}/g, '\t');

--- a/test/debug/index.test.js
+++ b/test/debug/index.test.js
@@ -1,5 +1,5 @@
 import 'preact/debug';
-import render from '../../src';
+import render from '../../src/index.js';
 import { h } from 'preact';
 import { expect } from 'chai';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
-import renderToString from '../src';
-import { default as renderToStringPretty, shallowRender } from '../src/jsx';
+import renderToString from '../src/index.js';
+import { default as renderToStringPretty, shallowRender } from '../src/jsx.js';
 import { expect } from 'chai';
 
 describe('render-to-string', () => {

--- a/test/jsx.test.js
+++ b/test/jsx.test.js
@@ -1,7 +1,7 @@
-import render from '../src/jsx';
+import render from '../src/jsx.js';
 import { h } from 'preact';
 import { expect } from 'chai';
-import { dedent } from './utils';
+import { dedent } from './utils.js';
 
 describe('jsx', () => {
 	let renderJsx = (jsx, opts) => render(jsx, null, opts).replace(/ {2}/g, '\t');

--- a/test/preact-render-to-string-tests.tsx
+++ b/test/preact-render-to-string-tests.tsx
@@ -1,4 +1,4 @@
-import render from '../src';
+import render from '../src/index.js';
 import { h } from 'preact';
 
 let vdom = <div class="foo">content</div>;

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -1,8 +1,8 @@
-import basicRender from '../src';
-import { render } from '../src/jsx';
+import basicRender from '../src/index.js';
+import { render } from '../src/jsx.js';
 import { h, Fragment } from 'preact';
 import { expect } from 'chai';
-import { dedent } from './utils';
+import { dedent } from './utils.js';
 
 describe('pretty', () => {
 	let prettyRender = (jsx) => render(jsx, {}, { pretty: true });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,6 +1,6 @@
-import render from '../src';
-import renderToStringPretty from '../src/pretty';
-import renderToStringJSX from '../src/jsx';
+import render from '../src/index.js';
+import renderToStringPretty from '../src/pretty.js';
+import renderToStringJSX from '../src/jsx.js';
 import {
 	h,
 	Component,

--- a/test/shallowRender.test.js
+++ b/test/shallowRender.test.js
@@ -1,4 +1,4 @@
-import { shallowRender } from '../src/jsx';
+import { shallowRender } from '../src/jsx.js';
 import { h, Fragment } from 'preact';
 import { expect } from 'chai';
 import { spy } from 'sinon';


### PR DESCRIPTION
Deno uses ESM resolution internally which requires file extensions, similar proper ESM in node and browsers. These changes shouldn't have any effect on the distributed package as we flatten the code to a single file before publish.