### PR TITLE
Add support for rendering HTML comments

### DIFF
--- a/.changeset/shy-hotels-impress.md
+++ b/.changeset/shy-hotels-impress.md
@@ -2,6 +2,4 @@
 'preact-render-to-string': minor
 ---
 
-Add ability to render comments via `<Fragment comment="my-comment" />`. When the `comment` prop is present all children of that `Fragment` will be ignored. This PR only supports that in server environments as it's useful to mark islands and other things. It's not supported in the browser.
-
-We picked a `Fragment` for this as it's the least common component and therefore the branch in our code with the least impact on perf by adding another if-check.
+Add experimental ability to render HTML comments via `<Fragment UNSTABLE_comment="my-comment" />`. When the `UNSTABLE_comment` prop is present all children of that `Fragment` will be ignored and a HTML comment will be rendered instead. This feature is added to allow framework authors to experiment with marking DOM for hydration in the client. Note that it's marked as unstable and might change in the future.

--- a/.changeset/shy-hotels-impress.md
+++ b/.changeset/shy-hotels-impress.md
@@ -1,0 +1,7 @@
+---
+'preact-render-to-string': minor
+---
+
+Add ability to render comments via `<Fragment comment="my-comment" />`. When the `comment` prop is present all children of that `Fragment` will be ignored. This PR only supports that in server environments as it's useful to mark islands and other things. It's not supported in the browser.
+
+We picked a `Fragment` for this as it's the least common component and therefore the branch in our code with the least impact on perf by adding another if-check.

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 	// Invoke rendering on Components
 	if (typeof type === 'function') {
 		if (type === Fragment) {
-			// Fragments are the least use components of core that's why
+			// Fragments are the least used components of core that's why
 			// branching here for comments has the least effect on perf.
 			if (props.comment) {
 				return '<!--' + encodeEntities(props.comment || '') + '-->';

--- a/src/index.js
+++ b/src/index.js
@@ -167,8 +167,8 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 		if (type === Fragment) {
 			// Fragments are the least used components of core that's why
 			// branching here for comments has the least effect on perf.
-			if (props.comment) {
-				return '<!--' + encodeEntities(props.comment || '') + '-->';
+			if (props.UNSTABLE_comment) {
+				return '<!--' + encodeEntities(props.UNSTABLE_comment || '') + '-->';
 			}
 
 			rendered = props.children;

--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,12 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 	// Invoke rendering on Components
 	if (typeof type === 'function') {
 		if (type === Fragment) {
+			// Fragments are the least use components of core that's why
+			// branching here for comments has the least effect on perf.
+			if (props.comment) {
+				return '<!--' + encodeEntities(props.comment || '') + '-->';
+			}
+
 			rendered = props.children;
 		} else {
 			contextType = type.contextType;

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1309,6 +1309,22 @@ describe('render', () => {
 		expect(render(<div>{() => {}}</div>)).to.equal('<div></div>');
 	});
 
+	describe('HTML Comments', () => {
+		it('should render HTML comments via Fragments', () => {
+			expect(render(<Fragment comment="foo" />)).to.equal('<!--foo-->');
+		});
+
+		it('should ignore children with comment prop', () => {
+			expect(
+				render(
+					<Fragment comment="foo">
+						<p>foo</p>
+					</Fragment>
+				)
+			).to.equal('<!--foo-->');
+		});
+	});
+
 	describe('vnode masks (useId)', () => {
 		it('should skip component top level Fragment child', () => {
 			const Wrapper = ({ children }) => <Fragment>{children}</Fragment>;

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1311,13 +1311,15 @@ describe('render', () => {
 
 	describe('HTML Comments', () => {
 		it('should render HTML comments via Fragments', () => {
-			expect(render(<Fragment comment="foo" />)).to.equal('<!--foo-->');
+			expect(render(<Fragment UNSTABLE_comment="foo" />)).to.equal(
+				'<!--foo-->'
+			);
 		});
 
 		it('should ignore children with comment prop', () => {
 			expect(
 				render(
-					<Fragment comment="foo">
+					<Fragment UNSTABLE_comment="foo">
 						<p>foo</p>
 					</Fragment>
 				)


### PR DESCRIPTION
This PR adds support for rendering HTML comments via `preact-render-to-string`. Instead of adding a new vnode type this leverages `Fragments`. This has the benefit that branching cost is minimal as `Fragments` are the least frequently used components and they sorta represent "nothing" in terms of client code.

`<Fragment UNSTABLE_comment="foobar" />` renders `<!--foobar-->`. When the prop is present, all other children are ignored.

This solves an issue with fresh which currently renders invalid HTML comments. Browsers happily parse over that, but it's annoying if you're testing with HTML validators on CI. See https://github.com/denoland/fresh/issues/838