### PR TITLE
Add support for `componentDidCatch` + `getDerivedStateFromError`

### DIFF
--- a/.changeset/cold-otters-argue.md
+++ b/.changeset/cold-otters-argue.md
@@ -1,0 +1,14 @@
+---
+'preact-render-to-string': minor
+---
+
+Add support for error boundaries via `componentDidCatch` and `getDerivedStateFromError`
+
+This feature is disabled by default and can be enabled by toggling the `errorBoundaries` option:
+
+```js
+import { options } from 'preact';
+
+// Enable error boundaries
+options.errorBoundaries = true;
+```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ app.get('/:fox', (req, res) => {
 });
 ```
 
+### Error Boundaries
+
+Rendering errors can be caught by Preact via `getDerivedStateFromErrors` or `componentDidCatch`. To enable that feature in `preact-render-to-string` set `errorBoundaries = true`
+
+```js
+import { options } from 'preact';
+
+// Enable error boundaries in `preact-render-to-string`
+options.errorBoundaries = true;
+```
+
 ---
 
 ### `Suspense` & `lazy` components with [`preact/compat`](https://www.npmjs.com/package/preact) & [`preact-ssr-prepass`](https://www.npmjs.com/package/preact-ssr-prepass)
@@ -94,50 +105,48 @@ npm install preact preact-render-to-string preact-ssr-prepass
 
 ```jsx
 export default () => {
-  return (
-    <h1>Home page</h1>
-  )
-}
+	return <h1>Home page</h1>;
+};
 ```
 
 ```jsx
-import { Suspense, lazy } from "preact/compat"
+import { Suspense, lazy } from 'preact/compat';
 
 // Creation of the lazy component
-const HomePage = lazy(() => import("./pages/home"))
+const HomePage = lazy(() => import('./pages/home'));
 
 const Main = () => {
-  return (
-    <Suspense fallback={<p>Loading</p>}>
-      <HomePage />
-    </Suspense>
-  )
-}
+	return (
+		<Suspense fallback={<p>Loading</p>}>
+			<HomePage />
+		</Suspense>
+	);
+};
 ```
 
 ```jsx
-import { render } from "preact-render-to-string"
-import prepass from "preact-ssr-prepass"
-import { Main } from "./main"
+import { render } from 'preact-render-to-string';
+import prepass from 'preact-ssr-prepass';
+import { Main } from './main';
 
 const main = async () => {
-  // Creation of the virtual DOM
-  const vdom = <Main />
-  
-  // Pre-rendering of lazy components
-  await prepass(vdom)
-  
-  // Rendering of components 
-  const html = render(vdom)
-  
-  console.log(html)
-  // <h1>Home page</h1>
-}
+	// Creation of the virtual DOM
+	const vdom = <Main />;
+
+	// Pre-rendering of lazy components
+	await prepass(vdom);
+
+	// Rendering of components
+	const html = render(vdom);
+
+	console.log(html);
+	// <h1>Home page</h1>
+};
 
 // Execution & error handling
-main().catch(error => {
-  console.error(error)
-})
+main().catch((error) => {
+	console.error(error);
+});
 ```
 
 ---


### PR DESCRIPTION
This PR adds support for error boundaries by supporting `componentDidCatch` and `getDerivedStateFromError`. To make this a non-breaking change this feature is disabled by default. It can be turned on by setting `options.errorBoundaries = true`.

This work is based on #66 and #67 .