### PR TITLE
Attribute hook render option

### DIFF
--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -8,6 +8,7 @@ interface Options {
 	functions?: boolean;
 	functionNames?: boolean;
 	skipFalseAttributes?: boolean;
+	attributeHook?: (name: string) => string;
 }
 
 export default function renderToStringPretty(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,27 +1,25 @@
 import { VNode } from 'preact';
 
-interface RenderOptions {
-	attrHook?: (name: string) => string;
+interface Options {
+	attributeHook?: (name: string) => string;
 }
 
 export default function renderToString(
 	vnode: VNode,
 	context?: any,
-	renderOpts?: RenderOptions
+	options?: Options
 ): string;
 
-export function render(
-	vnode: VNode,
-	context?: any,
-	renderOpts?: RenderOptions
-): string;
+export function render(vnode: VNode, context?: any, options?: Options): string;
+
 export function renderToString(
 	vnode: VNode,
 	context?: any,
-	renderOpts?: RenderOptions
+	options?: Options
 ): string;
+
 export function renderToStaticMarkup(
 	vnode: VNode,
 	context?: any,
-	renderOpts?: RenderOptions
+	options?: Options
 ): string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,27 @@
 import { VNode } from 'preact';
 
-export default function renderToString(vnode: VNode, context?: any): string;
+interface RenderOptions {
+	attrHook?: (name: string) => string;
+}
 
-export function render(vnode: VNode, context?: any): string;
-export function renderToString(vnode: VNode, context?: any): string;
-export function renderToStaticMarkup(vnode: VNode, context?: any): string;
+export default function renderToString(
+	vnode: VNode,
+	context?: any,
+	renderOpts?: RenderOptions
+): string;
+
+export function render(
+	vnode: VNode,
+	context?: any,
+	renderOpts?: RenderOptions
+): string;
+export function renderToString(
+	vnode: VNode,
+	context?: any,
+	renderOpts?: RenderOptions
+): string;
+export function renderToStaticMarkup(
+	vnode: VNode,
+	context?: any,
+	renderOpts?: RenderOptions
+): string;

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const isArray = Array.isArray;
 const assign = Object.assign;
 
 // Global state for the current render pass
-let beforeDiff, afterDiff, renderHook, ummountHook;
+let beforeDiff, afterDiff, renderHook, ummountHook, attrHook;
 
 /**
  * Render Preact JSX + Components to an HTML string.
@@ -29,7 +29,7 @@ let beforeDiff, afterDiff, renderHook, ummountHook;
  * @param {Object} [context={}] Initial root context object
  * @returns {string} serialized HTML
  */
-export function renderToString(vnode, context) {
+export function renderToString(vnode, context, renderOpts) {
 	// Performance optimization: `renderToString` is synchronous and we
 	// therefore don't execute any effects. To do that we pass an empty
 	// array to `options._commit` (`__c`). But we can go one step further
@@ -43,6 +43,7 @@ export function renderToString(vnode, context) {
 	afterDiff = options[DIFFED];
 	renderHook = options[RENDER];
 	ummountHook = options.unmount;
+	attrHook = renderOpts?.attrHook;
 
 	const parent = h(Fragment, null);
 	parent[CHILDREN] = [vnode];
@@ -398,6 +399,8 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 				}
 			}
 		}
+
+		if (attrHook) name = attrHook(name);
 
 		// write this attribute to the buffer
 		if (v != null && v !== false && typeof v !== 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const isArray = Array.isArray;
 const assign = Object.assign;
 
 // Global state for the current render pass
-let beforeDiff, afterDiff, renderHook, ummountHook, attrHook;
+let beforeDiff, afterDiff, renderHook, ummountHook, attributeHook;
 
 /**
  * Render Preact JSX + Components to an HTML string.
@@ -29,7 +29,7 @@ let beforeDiff, afterDiff, renderHook, ummountHook, attrHook;
  * @param {Object} [context={}] Initial root context object
  * @returns {string} serialized HTML
  */
-export function renderToString(vnode, context, renderOpts) {
+export function renderToString(vnode, context, opts) {
 	// Performance optimization: `renderToString` is synchronous and we
 	// therefore don't execute any effects. To do that we pass an empty
 	// array to `options._commit` (`__c`). But we can go one step further
@@ -43,7 +43,7 @@ export function renderToString(vnode, context, renderOpts) {
 	afterDiff = options[DIFFED];
 	renderHook = options[RENDER];
 	ummountHook = options.unmount;
-	attrHook = renderOpts?.attrHook;
+	attributeHook = opts && opts.attributeHook;
 
 	const parent = h(Fragment, null);
 	parent[CHILDREN] = [vnode];
@@ -400,7 +400,7 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 			}
 		}
 
-		if (attrHook) name = attrHook(name);
+		if (attributeHook) name = attributeHook(name);
 
 		// write this attribute to the buffer
 		if (v != null && v !== false && typeof v !== 'function') {

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -8,6 +8,7 @@ interface Options {
 	functions?: boolean;
 	functionNames?: boolean;
 	skipFalseAttributes?: boolean;
+	attributeHook?: (name: string) => string;
 }
 
 export default function renderToStringPretty(
@@ -15,6 +16,7 @@ export default function renderToStringPretty(
 	context?: any,
 	options?: Options
 ): string;
+
 export function render(vnode: VNode, context?: any, options?: Options): string;
 
 export function shallowRender(

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -25,7 +25,7 @@ let prettyFormatOpts = {
 	plugins: [preactPlugin]
 };
 
-function attributeHook(name, value, context, opts, isComponent) {
+function jsxAttributeHook(name, value, context, opts, isComponent) {
 	let type = typeof value;
 
 	// Use render-to-string's built-in handling for these properties
@@ -60,7 +60,7 @@ function attributeHook(name, value, context, opts, isComponent) {
 }
 
 let defaultOpts = {
-	attributeHook,
+	jsxAttributeHook,
 	jsx: true,
 	xml: false,
 	functions: true,
@@ -83,7 +83,7 @@ let defaultOpts = {
  */
 export default function renderToStringPretty(vnode, context, options) {
 	const opts = Object.assign({}, defaultOpts, options || {});
-	if (!opts.jsx) opts.attributeHook = null;
+	if (!opts.jsx || opts.attributeHook) opts.jsxAttributeHook = null;
 	return renderToString(vnode, context, opts);
 }
 export { renderToStringPretty as render };

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -209,6 +209,8 @@ function _renderToStringPretty(
 		propChildren,
 		html;
 
+	const attributeHook = opts && opts.attributeHook;
+
 	if (props) {
 		let attrs = Object.keys(props);
 
@@ -263,8 +265,8 @@ function _renderToStringPretty(
 			}
 
 			let hooked =
-				opts.attributeHook &&
-				opts.attributeHook(name, v, context, opts, isComponent);
+				opts.jsxAttributeHook &&
+				opts.jsxAttributeHook(name, v, context, opts, isComponent);
 			if (hooked || hooked === '') {
 				s = s + hooked;
 				continue;
@@ -280,6 +282,7 @@ function _renderToStringPretty(
 					v = name;
 					// in non-xml mode, allow boolean attributes
 					if (!opts || !opts.xml) {
+						if (attributeHook) name = attributeHook(name);
 						s = s + ' ' + name;
 						continue;
 					}
@@ -299,6 +302,7 @@ function _renderToStringPretty(
 						s = s + ` selected`;
 					}
 				}
+				if (attributeHook) name = attributeHook(name);
 				s = s + ` ${name}="${encodeEntities(v + '')}"`;
 			}
 		}

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1600,45 +1600,44 @@ describe('render', () => {
 	});
 
 	describe('Render Options', () => {
-		describe('Attribute Hook', () => {
-			it('Transforms attributes with custom attrHook option', () => {
-				function attrHook(name) {
-					const DASHED_ATTRS = /^(acceptC|httpE|(clip|color|fill|font|glyph|marker|stop|stroke|text|vert)[A-Z])/;
-					const CAMEL_ATTRS = /^(isP|viewB)/;
-					const COLON_ATTRS = /^(xlink|xml|xmlns)([A-Z])/;
-					const CAPITAL_REGEXP = /([A-Z])/g;
-					if (CAMEL_ATTRS.test(name)) return name;
-					if (DASHED_ATTRS.test(name))
-						return name.replace(CAPITAL_REGEXP, '-$1').toLowerCase();
-					if (COLON_ATTRS.test(name))
-						return name.replace(CAPITAL_REGEXP, ':$1').toLowerCase();
-					return name.toLowerCase();
-				}
+		it('transforms attributes with custom attributeHook option', () => {
+			function attributeHook(name) {
+				const DASHED_ATTRS = /^(acceptC|httpE|(clip|color|fill|font|glyph|marker|stop|stroke|text|vert)[A-Z])/;
+				const CAMEL_ATTRS = /^(isP|viewB)/;
+				const COLON_ATTRS = /^(xlink|xml|xmlns)([A-Z])/;
+				const CAPITAL_REGEXP = /([A-Z])/g;
+				if (CAMEL_ATTRS.test(name)) return name;
+				if (DASHED_ATTRS.test(name))
+					return name.replace(CAPITAL_REGEXP, '-$1').toLowerCase();
+				if (COLON_ATTRS.test(name))
+					return name.replace(CAPITAL_REGEXP, ':$1').toLowerCase();
+				return name.toLowerCase();
+			}
 
-				const content = (
-					<html>
-						<head>
-							<meta charSet="utf=8" />
-							<meta httpEquiv="refresh" />
-							<link rel="preconnect" href="https://foo.com" crossOrigin />
-						</head>
-						<body>
-							<img srcSet="foo.png, foo2.png 2x" />
-							<svg xmlSpace="preserve" viewBox="0 0 10 10" fillRule="nonzero">
-								<foreignObject>
-									<div xlinkHref="#" />
-								</foreignObject>
-							</svg>
-						</body>
-					</html>
-				);
+			const content = (
+				<html>
+					<head>
+						<meta charSet="utf=8" />
+						<meta httpEquiv="refresh" />
+						<link rel="preconnect" href="https://foo.com" crossOrigin />
+						<link rel="preconnect" href="https://bar.com" crossOrigin={false} />
+					</head>
+					<body>
+						<img srcSet="foo.png, foo2.png 2x" />
+						<svg xmlSpace="preserve" viewBox="0 0 10 10" fillRule="nonzero">
+							<foreignObject>
+								<div xlinkHref="#" />
+							</foreignObject>
+						</svg>
+					</body>
+				</html>
+			);
 
-				const expected =
-					'<html><head><meta charset="utf=8"/><meta http-equiv="refresh"/><link rel="preconnect" href="https://foo.com" crossorigin/></head><body><img srcset="foo.png, foo2.png 2x"/><svg xml:space="preserve" viewBox="0 0 10 10" fill-rule="nonzero"><foreignObject><div xlink:href="#"></div></foreignObject></svg></body></html>';
+			const expected =
+				'<html><head><meta charset="utf=8"/><meta http-equiv="refresh"/><link rel="preconnect" href="https://foo.com" crossorigin/><link rel="preconnect" href="https://bar.com"/></head><body><img srcset="foo.png, foo2.png 2x"/><svg xml:space="preserve" viewBox="0 0 10 10" fill-rule="nonzero"><foreignObject><div xlink:href="#"></div></foreignObject></svg></body></html>';
 
-				const rendered = render(content, {}, { attrHook });
-				expect(rendered).to.equal(expected);
-			});
+			const rendered = render(content, {}, { attributeHook });
+			expect(rendered).to.equal(expected);
 		});
 	});
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1598,4 +1598,47 @@ describe('render', () => {
 			});
 		});
 	});
+
+	describe('Render Options', () => {
+		describe('Attribute Hook', () => {
+			it('Transforms attributes with custom attrHook option', () => {
+				function attrHook(name) {
+					const DASHED_ATTRS = /^(acceptC|httpE|(clip|color|fill|font|glyph|marker|stop|stroke|text|vert)[A-Z])/;
+					const CAMEL_ATTRS = /^(isP|viewB)/;
+					const COLON_ATTRS = /^(xlink|xml|xmlns)([A-Z])/;
+					const CAPITAL_REGEXP = /([A-Z])/g;
+					if (CAMEL_ATTRS.test(name)) return name;
+					if (DASHED_ATTRS.test(name))
+						return name.replace(CAPITAL_REGEXP, '-$1').toLowerCase();
+					if (COLON_ATTRS.test(name))
+						return name.replace(CAPITAL_REGEXP, ':$1').toLowerCase();
+					return name.toLowerCase();
+				}
+
+				const content = (
+					<html>
+						<head>
+							<meta charSet="utf=8" />
+							<meta httpEquiv="refresh" />
+							<link rel="preconnect" href="https://foo.com" crossOrigin />
+						</head>
+						<body>
+							<img srcSet="foo.png, foo2.png 2x" />
+							<svg xmlSpace="preserve" viewBox="0 0 10 10" fillRule="nonzero">
+								<foreignObject>
+									<div xlinkHref="#" />
+								</foreignObject>
+							</svg>
+						</body>
+					</html>
+				);
+
+				const expected =
+					'<html><head><meta charset="utf=8"/><meta http-equiv="refresh"/><link rel="preconnect" href="https://foo.com" crossorigin/></head><body><img srcset="foo.png, foo2.png 2x"/><svg xml:space="preserve" viewBox="0 0 10 10" fill-rule="nonzero"><foreignObject><div xlink:href="#"></div></foreignObject></svg></body></html>';
+
+				const rendered = render(content, {}, { attrHook });
+				expect(rendered).to.equal(expected);
+			});
+		});
+	});
 });


### PR DESCRIPTION
Adds an attribute hook rendering option. This allows the user to customize how attribute name casing is rendered.
There have been several issues and attempts over years to implement this. Namely: #199

Seems the consensus is to do nothing because other frameworks don't and there isn't an agreeable set of regexes to handle everything, so instead let the user do it.

From my experience, the proper casing on some of these is absolutely critical. We've been maintaining a fork for years, and couldn't keep up syncing upstream improvements after v6 so this is a more non-invasive approach.