### PR TITLE
fix: escape a single quote

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ export const HTML_LOWER_CASE = /^accessK|^auto[A-Z]|^ch|^col|cont|cross|dateT|en
 export const SVG_CAMEL_CASE = /^ac|^ali|arabic|basel|cap|clipPath$|clipRule$|color|dominant|enable|fill|flood|font|glyph[^R]|horiz|image|letter|lighting|marker[^WUH]|overline|panose|pointe|paint|rendering|shape|stop|strikethrough|stroke|text[^L]|transform|underline|unicode|units|^v[^i]|^w|^xH/;
 
 // DOM properties that should NOT have "px" added when numeric
-const ENCODED_ENTITIES = /["&<]/;
+const ENCODED_ENTITIES = /["'&<]/;
 
 /** @param {string} str */
 export function encodeEntities(str) {
@@ -25,6 +25,9 @@ export function encodeEntities(str) {
 				break;
 			case 38:
 				ch = '&amp;';
+				break;
+			case 39:
+				ch = '&#x27;';
 				break;
 			case 60:
 				ch = '&lt;';

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -213,8 +213,8 @@ describe('render', () => {
 		});
 
 		it('should encode entities', () => {
-			let rendered = render(<div a={'"<>&'}>{'"<>&'}</div>),
-				expected = `<div a="&quot;&lt;>&amp;">&quot;&lt;>&amp;</div>`;
+			let rendered = render(<div a={'"\'<>&'}>{'"\'<>&'}</div>),
+				expected = `<div a="&quot;&#x27;&lt;>&amp;">&quot;&#x27;&lt;>&amp;</div>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
Hi,

Firstly, thank you for the great project.

In this PR, I've implemented the escaping of a single quote (0x27) to `&#x27;`. This modification will prevent the potential execution of scripts, as illustrated below:

```tsx
const value = "alert('bar!')";
return <div onMouseOver={value}>foo</div>;
```
