### PR TITLE
fix: mapped precompile children

### DIFF
--- a/.changeset/hip-beers-speak.md
+++ b/.changeset/hip-beers-speak.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix mapped children not working with Deno's new precompile JSX transform.

--- a/src/index.js
+++ b/src/index.js
@@ -192,8 +192,11 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 						const value = props.exprs[i];
 						if (value == null) continue;
 
-						// Check if we're dealing with a vnode
-						if (typeof value === 'object' && value.constructor === undefined) {
+						// Check if we're dealing with a vnode or an array of nodes
+						if (
+							typeof value === 'object' &&
+							(value.constructor === undefined || isArray(value))
+						) {
 							out += _renderToString(
 								value,
 								context,
@@ -203,7 +206,7 @@ function _renderToString(vnode, context, isSvgMode, selectValue, parent) {
 							);
 						} else {
 							// Values are pre-escaped by the JSX transform
-							out += props.exprs[i];
+							out += value;
 						}
 					}
 				}

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1673,5 +1673,18 @@ describe('render', () => {
 			let rendered = render(vnode);
 			expect(rendered).to.equal('<div>foo<span>bar</span></div>');
 		});
+
+		it('should render mapped children', () => {
+			let vnode = (
+				<Fragment
+					tpl={['<div>foo', '', '</div>']}
+					exprs={[<span>bar</span>, [<p>foo</p>, <p>bar</p>]]}
+				/>
+			);
+			let rendered = render(vnode);
+			expect(rendered).to.equal(
+				'<div>foo<span>bar</span><p>foo</p><p>bar</p></div>'
+			);
+		});
 	});
 });


### PR DESCRIPTION
This fixes an issue with Deno's new JSX precompile transform. The child expressions can also contain an Array in situations like this:

```jsx
<ul>
  {[1,2,3].map(x => <li key={x}>{x}</li>)}
  <li>4</li>
</ul>
```

...which is transformed to something lie this:

```jsx
const tpl = [
  "<ul>", "<li>4</li></ul>"
]

jsxTemplate(tpl, jsxEscape([1,2,3].map(x => ...)))
```

This case wasn't considered during rendering.