### PR TITLE
fix external type definitions of `renderToString`

### DIFF
--- a/.changeset/afraid-dolls-walk.md
+++ b/.changeset/afraid-dolls-walk.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch 
+---
+
+fix external type definitions of `renderToString`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { VNode } from 'preact';
 
-export default function renderToString(vnode: VNode, context?: any): string;
+export default function renderToString<P = {}>(vnode: VNode<P>, context?: any): string;
 
-export function render(vnode: VNode, context?: any): string;
-export function renderToString(vnode: VNode, context?: any): string;
-export function renderToStaticMarkup(vnode: VNode, context?: any): string;
+export function render<P = {}>(vnode: VNode<P>, context?: any): string;
+export function renderToString<P = {}>(vnode: VNode<P>, context?: any): string;
+export function renderToStaticMarkup<P = {}>(vnode: VNode<P>, context?: any): string;


### PR DESCRIPTION
Ran into type errors when running the following:

```typescript
renderToString(h(RootComponent, null));
```

This PR should fix it.

After checking if this change has any runtime implications, it seems that only `Fragment`s are affected. So, I've added a fix for that as well. Not sure why anyone would want a `Fragment` with `null` props though.