### PR TITLE
Remove incorrect second default export from jsx.d.ts

### DIFF
--- a/.changeset/early-rules-nail.md
+++ b/.changeset/early-rules-nail.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Remove incorrect second default export from jsx.d.ts

--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -17,5 +17,3 @@ export default function renderToStringPretty(
 ): string;
 
 export function shallowRender(vnode: VNode, context?: any): string;
-
-export default render;


### PR DESCRIPTION
This PR fixes https://github.com/preactjs/preact-render-to-string/issues/328, by removing the second default export from `jsx.d.ts`