### PR TITLE
Fixing nested Suspense boundaries in Simple Suspense Renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "6.2.2",
+	"version": "6.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-render-to-string",
-			"version": "6.2.2",
+			"version": "6.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"pretty-format": "^3.8.0"

--- a/test/compat/async.test.js
+++ b/test/compat/async.test.js
@@ -25,7 +25,7 @@ describe('Async renderToString', () => {
 		expect(rendered).to.equal(expected);
 	});
 
-	it('should render JSX with nested suspense boundary', async () => {
+	it('should render JSX with nested suspended components', async () => {
 		const {
 			Suspender: SuspenderOne,
 			suspended: suspendedOne
@@ -43,6 +43,42 @@ describe('Async renderToString', () => {
 						<SuspenderTwo>
 							<li>two</li>
 						</SuspenderTwo>
+						<li>three</li>
+					</SuspenderOne>
+				</Suspense>
+			</ul>
+		);
+
+		const expected = `<ul><li>one</li><li>two</li><li>three</li></ul>`;
+
+		suspendedOne.resolve();
+		suspendedTwo.resolve();
+
+		const rendered = await promise;
+
+		expect(rendered).to.equal(expected);
+	});
+
+	it('should render JSX with nested suspense boundaries', async () => {
+		const {
+			Suspender: SuspenderOne,
+			suspended: suspendedOne
+		} = createSuspender();
+		const {
+			Suspender: SuspenderTwo,
+			suspended: suspendedTwo
+		} = createSuspender();
+
+		const promise = renderToStringAsync(
+			<ul>
+				<Suspense fallback={null}>
+					<SuspenderOne>
+						<li>one</li>
+						<Suspense fallback={null}>
+							<SuspenderTwo>
+								<li>two</li>
+							</SuspenderTwo>
+						</Suspense>
 						<li>three</li>
 					</SuspenderOne>
 				</Suspense>


### PR DESCRIPTION
While I was working on a real-life application using lazy components (using `lazy` and `Suspense`) when I noticed that the rendered HTML sometimes contains `[object Promise]` instead of properly resolved component markup.

I did some debugging and I found out that this issue happens only when there are nested lazy components in the app (_App_ renders _ComponentA_ lazily, _ComponentA_ renders _ComponentB_ lazily), in this case _ComponentB_ is rendered as `[object Promise]`.

If I get it right, there is a test case for validating nested Suspense boundaries (`Async renderToString > should render JSX with nested suspense boundary`), but that test case does not contain nested Suspense boundaries, only a single Suspense boundary with multiple nested suspended components.

I think both use-cases are valid (having one Suspense boundary per suspended component, or only having one "top-level" Suspense boundary), so I kept the original test with a bit more explicit name, and added a new one for testing nested Suspense boundaries which replicates my original issue:

```
  1) Async renderToString
       should render JSX with nested suspense boundaries:

      AssertionError: expected '<ul><li>one</li>[object Promise]<li>t…' to equal '<ul><li>one</li><li>two</li><li>three…'
      + expected - actual

      -<ul><li>one</li>[object Promise]<li>three</li></ul>
      +<ul><li>one</li><li>two</li><li>three</li></ul>
      
      at Context.<anonymous> (test/compat/async.test.js:61:23)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

As a solution I opted into a `while` loop instead of implementing a _recursive Promise.all_, but I don't have strong opinions on this.