### PR TITLE
Fixing rendering multiple suspended components within one Suspense boundary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -427,9 +427,8 @@ function _renderToString(
 			rendered != null && rendered.type === Fragment && rendered.key == null;
 		rendered = isTopLevelFragment ? rendered.props.children : rendered;
 
-		try {
-			// Recurse into children before invoking the after-diff hook
-			const str = _renderToString(
+		const renderChildren = () =>
+			_renderToString(
 				rendered,
 				context,
 				isSvgMode,
@@ -437,6 +436,11 @@ function _renderToString(
 				vnode,
 				asyncMode
 			);
+
+		try {
+			// Recurse into children before invoking the after-diff hook
+			const str = renderChildren();
+
 			if (afterDiff) afterDiff(vnode);
 			vnode[PARENT] = undefined;
 
@@ -448,16 +452,18 @@ function _renderToString(
 
 			if (!error || typeof error.then !== 'function') throw error;
 
-			return error.then(() =>
-				_renderToString(
-					rendered,
-					context,
-					isSvgMode,
-					selectValue,
-					vnode,
-					asyncMode
-				)
-			);
+			const renderNestedChildren = () => {
+				try {
+					return renderChildren();
+				} catch (e) {
+					return e.then(
+						() => renderChildren(),
+						() => renderNestedChildren()
+					);
+				}
+			};
+
+			return error.then(() => renderNestedChildren());
 		}
 	}
 

--- a/test/compat/async.test.js
+++ b/test/compat/async.test.js
@@ -58,4 +58,37 @@ describe('Async renderToString', () => {
 
 		expect(rendered).to.equal(expected);
 	});
+
+	it('should render JSX with multiple suspended direct children within a single suspense boundary', async () => {
+		const {
+			Suspender: SuspenderOne,
+			suspended: suspendedOne
+		} = createSuspender();
+		const {
+			Suspender: SuspenderTwo,
+			suspended: suspendedTwo
+		} = createSuspender();
+
+		const promise = renderToStringAsync(
+			<ul>
+				<Suspense fallback={null}>
+					<SuspenderOne>
+						<li>one</li>
+					</SuspenderOne>
+					<SuspenderTwo>
+						<li>two</li>
+					</SuspenderTwo>
+				</Suspense>
+			</ul>
+		);
+
+		const expected = `<ul><li>one</li><li>two</li></ul>`;
+
+		suspendedOne.resolve();
+		suspendedTwo.resolve();
+
+		const rendered = await promise;
+
+		expect(rendered).to.equal(expected);
+	});
 });


### PR DESCRIPTION
Rendering a Suspense boundary which have multiple suspended components as children fails:

```ts
const promise = renderToStringAsync(
  <ul>
    <Suspense fallback={null}>
      <SuspenderOne>
        <li>one</li>
      </SuspenderOne>
      <SuspenderTwo>
        <li>two</li>
      </SuspenderTwo>
    </Suspense>
  </ul>
);
```

```
  1) Async renderToString
       should render JSX with multiple suspended direct children within a single suspense boundary:
     Error: the promise {} was thrown, throw an Error :)
```

I was curious so I trying to debug and fix this, what I found is:
- `_renderToString` (with `asyncMode: true`) throws a Promise while rendering the children of a component, if any of the children is a suspended component
- in this case the error Promise is caught, and once it resolves the same render is called again (without the try-catch this time)
- but when that second render throws again (e.g. when another suspended child component is still not resolved), that Promise is not caught

I changed this a bit by moving the _"render children, if that throws a Promise then render again once that Promise is resolved"_ bit to a function and re-using that whenever rendering a children. This way if a Suspense component has multiple suspended child components, we keep rendering until all of the promises are resolved.