### PR TITLE
fix: suspended error not re-thrown

### DIFF
--- a/.changeset/cuddly-spoons-impress.md
+++ b/.changeset/cuddly-spoons-impress.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix error thrown after suspending not being rethrown.

--- a/src/index.js
+++ b/src/index.js
@@ -467,6 +467,8 @@ function _renderToString(
 				try {
 					return renderChildren();
 				} catch (e) {
+					if (!e || typeof e.then !== 'function') throw e;
+
 					return e.then(
 						() => renderChildren(),
 						() => renderNestedChildren()

--- a/test/compat/async.test.js
+++ b/test/compat/async.test.js
@@ -137,4 +137,32 @@ describe('Async renderToString', () => {
 
 		expect(rendered).to.equal(expected);
 	});
+
+	it('should rethrow error thrown after suspending', async () => {
+		const { suspended, getResolved } = createSuspender();
+
+		function Suspender() {
+			if (!getResolved()) {
+				throw suspended.promise;
+			}
+
+			throw new Error('fail');
+		}
+
+		const promise = renderToStringAsync(
+			<Suspense fallback={<div>loading...</div>}>
+				<Suspender />
+			</Suspense>
+		);
+
+		let msg = '';
+		try {
+			suspended.resolve();
+			await promise;
+		} catch (err) {
+			msg = err.message;
+		}
+
+		expect(msg).to.equal('fail');
+	});
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -27,6 +27,9 @@ export function createSuspender() {
 	}
 
 	return {
+		getResolved() {
+			return resolved;
+		},
 		suspended: deferred,
 		Suspender
 	};


### PR DESCRIPTION
When an error was thrown after suspending a component we didn't rethrow it. This lead to a cryptic `e.then is not a function` error instead of the expected error message.