### PR TITLE
fix: invalid `vnode._parent` value

### DIFF
--- a/.changeset/proud-eyes-cheer.md
+++ b/.changeset/proud-eyes-cheer.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix invalid parent pointer empty value when rendering a suspended vnode

--- a/src/index.js
+++ b/src/index.js
@@ -425,7 +425,7 @@ function _renderToString(
 					return str;
 				} finally {
 					if (afterDiff) afterDiff(vnode);
-					vnode[PARENT] = undefined;
+					vnode[PARENT] = null;
 
 					if (ummountHook) ummountHook(vnode);
 				}
@@ -453,7 +453,7 @@ function _renderToString(
 			const str = renderChildren();
 
 			if (afterDiff) afterDiff(vnode);
-			vnode[PARENT] = undefined;
+			vnode[PARENT] = null;
 
 			if (ummountHook) ummountHook(vnode);
 
@@ -618,7 +618,7 @@ function _renderToString(
 	}
 
 	if (afterDiff) afterDiff(vnode);
-	vnode[PARENT] = undefined;
+	vnode[PARENT] = null;
 	if (ummountHook) ummountHook(vnode);
 
 	// Emit self-closing tag for empty void elements:


### PR DESCRIPTION
We have lots of code in hooks that checks for this being `null` when empty. This broke with `preact-render-to-string` because we did set it to `undefined` on reset here and caused the `useId()` hook to throw an error.