### PR TITLE
fix: precompile template empty HTML

### DIFF
--- a/.changeset/nine-buckets-pull.md
+++ b/.changeset/nine-buckets-pull.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix JSX template being detected as a top level Fragment when Deno's jsx `precompile` option is used

--- a/src/index.js
+++ b/src/index.js
@@ -435,7 +435,10 @@ function _renderToString(
 		// When a component returns a Fragment node we flatten it in core, so we
 		// need to mirror that logic here too
 		let isTopLevelFragment =
-			rendered != null && rendered.type === Fragment && rendered.key == null;
+			rendered != null &&
+			rendered.type === Fragment &&
+			rendered.key == null &&
+			rendered.props.tpl == null;
 		rendered = isTopLevelFragment ? rendered.props.children : rendered;
 
 		const renderChildren = () =>

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -1686,5 +1686,18 @@ describe('render', () => {
 				'<div>foo<span>bar</span><p>foo</p><p>bar</p></div>'
 			);
 		});
+
+		it('should bypass top level fragment detection', () => {
+			function Foo(props) {
+				return props.children;
+			}
+			let vnode = (
+				<Foo>
+					<Fragment tpl={['<div>foo', '</div>']} exprs={[<span>bar</span>]} />
+				</Foo>
+			);
+			let rendered = render(vnode);
+			expect(rendered).to.equal('<div>foo<span>bar</span></div>');
+		});
 	});
 });


### PR DESCRIPTION
Since we use a `Fragment` for the template we need to ensure that we don't fall into the logic where we detect if a component returned a top level `Fragment`.

This fixes an issue discovered when using Preact with Deno's `precompile` JSX transform.