### PR TITLE
perf: remove unnecessary closure

### DIFF
--- a/.changeset/perfect-hounds-joke.md
+++ b/.changeset/perfect-hounds-joke.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Perf: Remove unnecessary closure when rendering child nodes


### PR DESCRIPTION
This removes a closure that isn't necessary when rendering vnode children.