### PR TITLE
refactor: Build scripts & output directories

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -9,6 +9,6 @@ const copy = (filename) => {
 };
 
 copy('index');
-copy('jsx');
-copy('stream');
-copy('stream-node');
+copy('jsx/index');
+copy('stream/index');
+copy('stream/node/index');

--- a/config/node-commonjs.js
+++ b/config/node-commonjs.js
@@ -8,7 +8,6 @@ const filePath = (file) => path.join(process.cwd(), 'dist', file);
 
 // Main entry
 fs.copyFileSync(filePath('index.js'), filePath('commonjs.js'));
-fs.copyFileSync(filePath('index.js.map'), filePath('commonjs.js.map'));
 
 const source = [
 	`const mod = require('./commonjs');`,
@@ -21,13 +20,12 @@ const source = [
 fs.writeFileSync(filePath('index.js'), source, 'utf-8');
 
 // JSX entry
-fs.copyFileSync(filePath('jsx.js'), filePath('jsx-entry.js'));
-fs.copyFileSync(filePath('jsx.js.map'), filePath('jsx-entry.js.map'));
+fs.copyFileSync(filePath('jsx/index.js'), filePath('jsx/commonjs.js'));
 
 const sourceJsx = [
-	`const entry = require('./jsx-entry');`,
+	`const entry = require('./commonjs');`,
 	`entry.default.render = entry.render;`,
 	`entry.default.shallowRender = entry.shallowRender;`,
 	`module.exports = entry.default;`
 ].join('\n');
-fs.writeFileSync(filePath('jsx.js'), sourceJsx, 'utf-8');
+fs.writeFileSync(filePath('jsx/index.js'), sourceJsx, 'utf-8');

--- a/config/node-verify-exports.js
+++ b/config/node-verify-exports.js
@@ -20,14 +20,14 @@ assert(typeof mainCjs.render === 'function');
 })();
 
 // JSX CJS
-const jsxCjs = require(filePath('jsx.js'));
+const jsxCjs = require(filePath('jsx/index.js'));
 assert(typeof jsxCjs === 'function');
 assert(typeof jsxCjs.render === 'function');
 assert(typeof jsxCjs.shallowRender === 'function');
 
 // JSX ESM
 (async () => {
-	const jsxESM = await import(filePath('jsx.mjs'));
+	const jsxESM = await import(filePath('jsx/index.mjs'));
 	assert(typeof jsxESM.default === 'function');
 	assert(typeof jsxESM.render === 'function');
 	assert(typeof jsxESM.shallowRender === 'function');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "preact-render-to-string",
 			"version": "6.5.2",
 			"license": "MIT",
-			"dependencies": {
-				"pretty-format": "^3.8.0"
-			},
 			"devDependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.12.12",
 				"@babel/preset-env": "^7.12.11",
@@ -29,6 +26,7 @@
 				"mocha": "^8.2.1",
 				"preact": "^10.13.0",
 				"prettier": "^2.2.1",
+				"pretty-format": "^3.8.0",
 				"sinon": "^9.2.2",
 				"sinon-chai": "^3.5.0",
 				"typescript": "^5.0.0",
@@ -10937,7 +10935,8 @@
 		"node_modules/pretty-format": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-			"integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
+			"integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
+			"dev": true
 		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,43 +7,44 @@
 	"umd:main": "dist/index.umd.js",
 	"module": "dist/index.module.js",
 	"jsnext:main": "dist/index.module.js",
-	"types": "src/index.d.ts",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./src/index.d.ts",
+			"types": "./dist/index.d.ts",
 			"browser": "./dist/index.module.js",
 			"umd": "./dist/index.umd.js",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.js"
 		},
 		"./jsx": {
-			"types": "./jsx.d.ts",
-			"browser": "./dist/jsx.module.js",
-			"umd": "./dist/jsx.umd.js",
-			"import": "./dist/jsx.mjs",
-			"require": "./dist/jsx.js"
+			"types": "./dist/jsx.d.ts",
+			"browser": "./dist/jsx/index.module.js",
+			"umd": "./dist/jsx/index.umd.js",
+			"import": "./dist/jsx/index.mjs",
+			"require": "./dist/jsx/index.js"
 		},
 		"./stream": {
 			"types": "./dist/stream.d.ts",
-			"browser": "./dist/stream.module.js",
-			"import": "./dist/stream.mjs",
-			"require": "./dist/stream.js"
+			"browser": "./dist/stream/index.module.js",
+			"import": "./dist/stream/index.mjs",
+			"require": "./dist/stream/index.js"
 		},
 		"./stream-node": {
 			"types": "./dist/stream-node.d.ts",
-			"import": "./dist/stream-node.mjs",
-			"require": "./dist/stream-node.js"
+			"import": "./dist/stream/node/index.mjs",
+			"require": "./dist/stream/node/index.js"
 		},
 		"./package.json": "./package.json"
 	},
 	"scripts": {
 		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",
 		"bench:v8": "BABEL_ENV=test microbundle benchmarks/index.js -f modern --alias benchmarkjs-pretty=benchmarks/lib/benchmark-lite.js --external none --target node --no-compress --no-sourcemap --raw -o benchmarks/.v8.mjs && v8 --module benchmarks/.v8.modern.js",
-		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s transpile:stream && npm run -s copy-typescript-definition",
+		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s transpile:stream && npm run -s transpile:stream-node && npm run -s copy-typescript-definition",
 		"postbuild": "node ./config/node-13-exports.js && node ./config/node-commonjs.js && node ./config/node-verify-exports.js",
-		"transpile": "microbundle src/index.js -f es,cjs,umd --target web --external preact",
-		"transpile:stream": "microbundle src/stream.js -o dist/stream.js -f es,cjs,umd --external preact && microbundle src/stream-node.js -o dist/stream-node.js -f es,cjs,umd --target node --external preact",
-		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx.js --target web --external preact && microbundle dist/jsx.js -o dist/jsx.js -f cjs --external preact",
+		"transpile": "microbundle src/index.js -f es,cjs,umd",
+		"transpile:stream": "microbundle src/stream.js -o dist/stream/index.js -f es,cjs,umd",
+		"transpile:stream-node": "microbundle src/stream-node.js -o dist/stream/node/index.js -f es,cjs,umd --target node",
+		"transpile:jsx": "microbundle src/jsx.js -o dist/jsx/index.js -f es,cjs,umd && microbundle dist/jsx/index.js -o dist/jsx/index.js -f cjs",
 		"copy-typescript-definition": "copyfiles -f src/*.d.ts dist",
 		"test": "eslint src test && tsc && npm run test:mocha && npm run test:mocha:compat && npm run test:mocha:debug && npm run bench",
 		"test:mocha": "BABEL_ENV=test mocha -r @babel/register -r test/setup.js test/*.test.jsx",
@@ -143,13 +144,11 @@
 		"baseline-rts": "npm:preact-render-to-string@latest",
 		"preact": "^10.13.0",
 		"prettier": "^2.2.1",
+		"pretty-format": "^3.8.0",
 		"sinon": "^9.2.2",
 		"sinon-chai": "^3.5.0",
 		"typescript": "^5.0.0",
 		"web-streams-polyfill": "^3.2.1"
-	},
-	"dependencies": {
-		"pretty-format": "^3.8.0"
 	},
 	"prettier": {
 		"singleQuote": true,

--- a/test/preact-render-to-string-tests.tsx
+++ b/test/preact-render-to-string-tests.tsx
@@ -1,7 +1,0 @@
-import render from '../src/index.js';
-import { h } from 'preact';
-
-let vdom = <div class="foo">content</div>;
-
-let html = render(vdom);
-console.log(html);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "src/index.d.ts",
-        "test/preact-render-to-string-tests.tsx"
+        "src/index.d.ts"
     ]
 }


### PR DESCRIPTION
Builds on top of #362-ish

Does a few things:

- Output in `dist/` is now nested per export
  - Makes it so much easier to debug/deal with when the exports aren't all at same level.
- Simplifies & makes build scripts a tad more consistent
- Drops `pretty-format` dependency -- it's already inlined into the export that uses it. It's not a heavy dep, but entirely unused all the same.