### PR TITLE
fix: insert ooo chunks in the proper order

### DIFF
--- a/.changeset/quick-goats-end.md
+++ b/.changeset/quick-goats-end.md
@@ -1,0 +1,6 @@
+---
+"preact-render-to-string": patch
+---
+
+fix: stop client runtime from being corrupted
+fix: insert ooo chunks in the proper order

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -1,51 +1,52 @@
 /* eslint-disable no-var, key-spacing, object-curly-spacing, prefer-arrow-callback, semi, keyword-spacing */
 
-function initPreactIslandElement() {
-	class PreactIslandElement extends HTMLElement {
-		connectedCallback() {
-			var d = this;
-			if (!d.isConnected) return;
+// function initPreactIslandElement() {
+// 	class PreactIslandElement extends HTMLElement {
+// 		connectedCallback() {
+// 			var d = this;
+// 			if (!d.isConnected) return;
 
-			let i = this.getAttribute('data-target');
-			if (!i) return;
+// 			let i = this.getAttribute('data-target');
+// 			if (!i) return;
 
-			var s,
-				e,
-				c = document.createNodeIterator(document, 128);
-			while (c.nextNode()) {
-				let n = c.referenceNode;
+// 			var s,
+// 				e,
+// 				c = document.createNodeIterator(document, 128);
+// 			while (c.nextNode()) {
+// 				let n = c.referenceNode;
 
-				if (n.data == 'preact-island:' + i) s = n;
-				else if (n.data == '/preact-island:' + i) e = n;
-				if (s && e) break;
-			}
-			if (s && e) {
-				var p = e.previousSibling;
-				while (p != s) {
-					if (!p || p == s) break;
-					e.parentNode.removeChild(p);
-					p = e.previousSibling;
-				}
+// 				if (n.data == 'preact-island:' + i) s = n;
+// 				else if (n.data == '/preact-island:' + i) e = n;
+// 				if (s && e) break;
+// 			}
+// 			if (s && e) {
+// 				requestAnimationFrame(() => {
+// 					var p = e.previousSibling;
+// 					while (p != s) {
+// 						if (!p || p == s) break;
+// 						e.parentNode.removeChild(p);
+// 						p = e.previousSibling;
+// 					}
 
-				requestAnimationFrame(() => {
-					for (let i = 0; i <= d.children.length; i++) {
-						const child = d.children[i];
-						e.parentNode.insertBefore(child, e);
-					}
+// 					c = s;
+// 					while (d.firstChild) {
+// 						s = d.firstChild;
+// 						d.removeChild(s);
+// 						c.after(s);
+// 						c = s;
+// 					}
 
-					d.parentNode.removeChild(d);
-				});
-			}
-		}
-	}
+// 					d.parentNode.removeChild(d);
+// 				});
+// 			}
+// 		}
+// 	}
 
-	customElements.define('preact-island', PreactIslandElement);
-}
+// 	customElements.define('preact-island', PreactIslandElement);
+// }
 
-const fn = initPreactIslandElement.toString();
-const INIT_SCRIPT = fn
-	.slice(fn.indexOf('{') + 1, fn.lastIndexOf('}'))
-	.replace(/\n\s+/gm, '');
+// To modify the INIT_SCRIPT, uncomment the above code, modify it, and paste it into https://try.terser.org/.
+const INIT_SCRIPT = `class e extends HTMLElement{connectedCallback(){var e=this;if(!e.isConnected)return;let t=this.getAttribute("data-target");if(t){for(var r,a,i=document.createNodeIterator(document,128);i.nextNode();){let e=i.referenceNode;if(e.data=="preact-island:"+t?r=e:e.data=="/preact-island:"+t&&(a=e),r&&a)break}r&&a&&requestAnimationFrame((()=>{for(var t=a.previousSibling;t!=r&&t&&t!=r;)a.parentNode.removeChild(t),t=a.previousSibling;for(i=r;e.firstChild;)r=e.firstChild,e.removeChild(r),i.after(r),i=r;e.parentNode.removeChild(e)}))}}}customElements.define("preact-island",e);`;
 
 export function createInitScript() {
 	return `<script>(function(){${INIT_SCRIPT}}())</script>`;


### PR DESCRIPTION
fix: stop client runtime from being corrupted

This does two things
1.) the current logic to move OOO children doesn't support multiple children, and is kinda just wrong
2.) puts the client OOO runtime into a string to stop corruption by bundlers such as Vite