### PR TITLE
fix: allow any stringified value in class + className

### DIFF
--- a/.changeset/metal-bottles-play.md
+++ b/.changeset/metal-bottles-play.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Allow any value for `class` + `className` as long as it's stringified to match browser behavior.

--- a/src/index.js
+++ b/src/index.js
@@ -543,7 +543,9 @@ function _renderToString(
 	for (let name in props) {
 		let v = props[name];
 
-		if (typeof v == 'function') continue;
+		if (typeof v == 'function' && name !== 'class' && name !== 'className') {
+			continue;
+		}
 
 		switch (name) {
 			case 'children':

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -1678,6 +1678,18 @@ describe('render', () => {
 				}
 			}
 		});
+
+		// https://github.com/preactjs/preact-render-to-string/issues/390
+		// The DOM API casts any value to a string here.
+		it('should cast "className" and "class" value to string', () => {
+			const proxy = new Proxy(() => {}, {
+				get() {
+					return () => 'foo';
+				}
+			});
+			let rendered = render(<div className={proxy} />);
+			expect(rendered).to.equal(`<div class="foo"></div>`);
+		});
 	});
 
 	describe('precompiled JSX', () => {


### PR DESCRIPTION
Seems fine to merge, but then again this seems cursed and I'm worried that this list will get longer. For now it seems fine though.

Fixes https://github.com/preactjs/preact-render-to-string/issues/390