### PR TITLE
chore: Run build prior to running benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,4 @@ jobs:
           cache: npm
       - run: npm ci
       - name: test
-        # Not using `npm test` since it rebuilds source which npm ci has already done
-        run: |
-          npm run build
-          npm run test
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"./package.json": "./package.json"
 	},
 	"scripts": {
+		"prebench": "npm run build",
 		"bench": "BABEL_ENV=test node -r @babel/register benchmarks index.js",
 		"bench:v8": "BABEL_ENV=test microbundle benchmarks/index.js -f modern --alias benchmarkjs-pretty=benchmarks/lib/benchmark-lite.js --external none --target node --no-compress --no-sourcemap --raw -o benchmarks/.v8.mjs && v8 --module benchmarks/.v8.modern.js",
 		"build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s transpile:stream && npm run -s transpile:stream-node && npm run -s copy-typescript-definition",


### PR DESCRIPTION
Locally I was seeing some bizarre numbers for the "current" bench, about 50% faster. Took me a few minutes to realize I had an old build sitting around 😅 

I think this setup should work better? As the bench uses the built files from `/dist`, you'll always want to run a build whilst playing with the benchmarks. The tests themselves use the source files though, so they don't inherently need it.