### PR TITLE
chore: Bump preact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "6.5.10",
+	"version": "6.5.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-render-to-string",
-			"version": "6.5.10",
+			"version": "6.5.11",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -25,7 +25,7 @@
 				"lint-staged": "^10.5.3",
 				"microbundle": "^0.15.1",
 				"mocha": "^8.2.1",
-				"preact": "^10.13.0",
+				"preact": "^10.24.0",
 				"prettier": "^2.2.1",
 				"pretty-format": "^3.8.0",
 				"sinon": "^9.2.2",
@@ -2488,12 +2488,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/autoprefixer/node_modules/caniuse-lite": {
-			"version": "1.0.30001171",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-			"integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
-			"dev": true
-		},
 		"node_modules/babel-eslint": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -2895,12 +2889,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/browserslist/node_modules/caniuse-lite": {
-			"version": "1.0.30001171",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-			"integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
-			"dev": true
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -3010,10 +2998,25 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001022",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz",
-			"integrity": "sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==",
-			"dev": true
+			"version": "1.0.30001662",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
+			"integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chai": {
 			"version": "4.2.0",
@@ -4565,12 +4568,6 @@
 			"engines": {
 				"node": ">=9.x"
 			}
-		},
-		"node_modules/eslint-plugin-compat/node_modules/caniuse-lite": {
-			"version": "1.0.30001171",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-			"integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==",
-			"dev": true
 		},
 		"node_modules/eslint-plugin-compat/node_modules/semver": {
 			"version": "7.3.2",
@@ -10832,10 +10829,11 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.13.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.13.1.tgz",
-			"integrity": "sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==",
+			"version": "10.24.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.24.0.tgz",
+			"integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 		"lint-staged": "^10.5.3",
 		"microbundle": "^0.15.1",
 		"mocha": "^8.2.1",
-		"preact": "^10.13.0",
+		"preact": "^10.24.0",
 		"prettier": "^2.2.1",
 		"pretty-format": "^3.8.0",
 		"sinon": "^9.2.2",

--- a/test/compat/index.test.jsx
+++ b/test/compat/index.test.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 describe('compat', () => {
 	it('should not duplicate class attribute when className is empty', async () => {
 		let rendered = render(createElement('div', { className: '' }));
-		let expected = `<div class></div>`;
+		let expected = `<div></div>`;
 
 		expect(rendered).to.equal(expected);
 	});


### PR DESCRIPTION
Workin' on the ecosystem CI, came across this.

The test case change is due to this: https://github.com/preactjs/preact/pull/3941/files#r1144722263