### PR TITLE
refactor: Switch `HTML_LOWER_CASE` rgx to always match from line start

### DIFF
--- a/.changeset/kind-pumas-wash.md
+++ b/.changeset/kind-pumas-wash.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Switch `HTML_LOWER_CASE` regex to match all from line start for a marginal perf benefit.

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,7 +1,7 @@
 export const VOID_ELEMENTS = /^(?:area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 export const UNSAFE_NAME = /[\s\n\\/='"\0<>]/;
 export const NAMESPACE_REPLACE_REGEX = /^(xlink|xmlns|xml)([A-Z])/;
-export const HTML_LOWER_CASE = /^accessK|^auto[A-Z]|^cell|^ch|^col|cont|cross|dateT|encT|form[A-Z]|frame|hrefL|inputM|maxL|minL|noV|playsI|popoverT|readO|rowS|src[A-Z]|tabI|useM|item[A-Z]/;
+export const HTML_LOWER_CASE = /^(?:accessK|auto[A-Z]|cell|ch|col|cont|cross|dateT|encT|form[A-Z]|frame|hrefL|inputM|maxL|minL|noV|playsI|popoverT|readO|rowS|src[A-Z]|tabI|useM|item[A-Z])/;
 export const SVG_CAMEL_CASE = /^ac|^ali|arabic|basel|cap|clipPath$|clipRule$|color|dominant|enable|fill|flood|font|glyph[^R]|horiz|image|letter|lighting|marker[^WUH]|overline|panose|pointe|paint|rendering|shape|stop|strikethrough|stroke|text[^L]|transform|underline|unicode|units|^v[^i]|^w|^xH/;
 
 // Boolean DOM properties that translate to enumerated ('true'/'false') attributes


### PR DESCRIPTION
Should be marginally faster, and these patterns are all written for line start anyhow -- we don't intend to match `foobarbaztabIndex`.