### PR TITLE
chore: fix test assertion

### DIFF
--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -49,13 +49,13 @@ describe('render', () => {
 					);
 				}
 				let rendered = render(
-					<div class="foo">
+					<div>
 						x<a>a</a>
 						<b>b</b>c{children}d
 					</div>
 				);
 
-				expect(rendered).not.to.contain(/\s/);
+				expect(rendered).not.to.match(/\s/);
 			});
 
 			it('should not indent when attributes contain newlines', () => {


### PR DESCRIPTION
Randomly noticed an incorrect test assertion while looking through our tests. When you pass a regex to `.contain()` in `chai` it will cast it to a string and the rendered output does indeed not contain the string `/\s/`.

It should've been `.match()` instead. And because there is a space between an element name and an attribute, that needs to be removed too.