### PR TITLE
improve perf with array pre-allocate

### DIFF
--- a/.changeset/giant-schools-explode.md
+++ b/.changeset/giant-schools-explode.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Improve performance by pre-allocating arrays

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@babel/register": "^7.12.10",
 				"@changesets/changelog-github": "^0.4.1",
 				"@changesets/cli": "^2.18.0",
-				"baseline-rts": "npm:preact-render-to-string@latest",
+				"baseline-rts": "npm:preact-render-to-string@6.5.11",
 				"benchmarkjs-pretty": "^2.0.1",
 				"chai": "^4.2.0",
 				"check-export-map": "^1.3.1",
@@ -2561,11 +2561,10 @@
 		},
 		"node_modules/baseline-rts": {
 			"name": "preact-render-to-string",
-			"version": "6.5.10",
-			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.10.tgz",
-			"integrity": "sha512-BJdypTQaBA5UbTF9NKZS3zP93Sw33tZOxNXIfuHofqOZFoMdsquNkVebs/HkEw0in/Qbi6Ep/Anngnj+VsHeBQ==",
+			"version": "6.5.11",
+			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+			"integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
 			"dev": true,
-			"license": "MIT",
 			"peerDependencies": {
 				"preact": ">=10"
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -244,7 +244,8 @@ function _renderToString(
 		let rendered = EMPTY_STR,
 			renderArray;
 		parent[CHILDREN] = vnode;
-		for (let i = 0; i < vnode.length; i++) {
+		const vnodeLength = vnode.length;
+		for (let i = 0; i < vnodeLength; i++) {
 			let child = vnode[i];
 			if (child == null || typeof child == 'boolean') continue;
 
@@ -262,7 +263,7 @@ function _renderToString(
 				rendered = rendered + childRender;
 			} else {
 				if (!renderArray) {
-					renderArray = [];
+					renderArray = new Array(vnodeLength);
 				}
 
 				if (rendered) renderArray.push(rendered);


### PR DESCRIPTION
```
Text:
baseline x 434.471 ops/sec ±2.09 (89 runs sampled)
current x 455.816 ops/sec ±1.35 (88 runs sampled)

Fastest is current

SearchResults:
baseline x 2,124.763 ops/sec ±3.50 (92 runs sampled)
current x 2,174.318 ops/sec ±4.29 (88 runs sampled)

Fastest is current

ColorPicker:
baseline x 12,934.781 ops/sec ±1.34 (95 runs sampled)
current x 13,121.543 ops/sec ±0.87 (97 runs sampled)

Fastest is current
```