### PR TITLE
renderToPipeableStream: Expose errors through onError, no longer emit un-catchable error event on internal stream

### DIFF
--- a/.changeset/mighty-keys-admire.md
+++ b/.changeset/mighty-keys-admire.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+renderToPipeableStream: expose errors through onError, no longer emit un-catchable error event on internal stream

--- a/src/stream-node.d.ts
+++ b/src/stream-node.d.ts
@@ -8,7 +8,7 @@ interface RenderToPipeableStreamOptions {
 }
 
 interface PipeableStream {
-	abort: () => void;
+	abort: (reason?: unknown) => void;
 	pipe: (writable: WritableStream) => void;
 }
 


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact-render-to-string/issues/404

Changes error and abort handling in `renderToPipeableStream` so the stream no longer emits an uncatchable error event. Instead errors are passed to `options.onError` if provided. If there is no error callback it's rethrown, though maybe that's not ideal since it happens in the async chain, so can't really be caught either. Alternatively this could just `console.error`, so it doesn't get silently swallowed entirely? 

Also added an optional `reason` argument for `stream.abort()`, defaulting to `new Error(The render was aborted by the server without a reason.)` inspired by React. Previously this was just `new Error('aborted')`, though this was never exposed to consumers.
Abort still destroys the stream, and also calls the `onError` callback (if defined) with the reason