### PR TITLE
Use generic type for vnode props in renderToReadableStream/renderToPipeableStream

### DIFF
--- a/.changeset/little-rocks-doubt.md
+++ b/.changeset/little-rocks-doubt.md
@@ -2,4 +2,4 @@
 'preact-render-to-string': patch
 ---
 
-Fix types for `/stream` and `/stream-node` exports
+Ensure the renderToStream types of `/stream` and `/stream-node` accept a generic for the props of the passed in VNode

--- a/.changeset/little-rocks-doubt.md
+++ b/.changeset/little-rocks-doubt.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix types for `/stream` and `/stream-node` exports

--- a/src/stream-node.d.ts
+++ b/src/stream-node.d.ts
@@ -12,8 +12,8 @@ interface PipeableStream {
 	pipe: (writable: WritableStream) => void;
 }
 
-export function renderToPipeableStream(
-	vnode: VNode,
+export function renderToPipeableStream<P = {}>(
+	vnode: VNode<P>,
 	options: RenderToPipeableStreamOptions,
 	context?: any
 ): PipeableStream;

--- a/src/stream.d.ts
+++ b/src/stream.d.ts
@@ -4,7 +4,7 @@ interface RenderStream extends ReadableStream<Uint8Array> {
 	allReady: Promise<void>;
 }
 
-export function renderToReadableStream(
-	vnode: VNode,
+export function renderToReadableStream<P = {}>(
+	vnode: VNode<P>,
 	context?: any
 ): RenderStream;


### PR DESCRIPTION
Currently the `vnode` argument for these two functions always defaults to `VNode` (which defaults to `VNode<{}>`), this causes issues with *some* arguments that are otherwise valid (and run fine, it's purely a TypeScript typecheck issue).

```typescript
const Context = createContext({});
renderToPipeableStream(h(Context.Provider, { value: {} }), {});
```
```
/*
src/index.ts:6:24 - error TS2345: Argument of type 'VNode<Attributes & { value: {}; children?: ComponentChildren; }>' is not assignable to parameter of type 'VNode<{}>'.
  Types of property 'type' are incompatible.
    Type 'string | ComponentType<Attributes & { value: {}; children?: ComponentChildren; }>' is not assignable to type 'string | ComponentType<{}>'.
      Type 'ComponentClass<Attributes & { value: {}; children?: ComponentChildren; }, {}>' is not assignable to type 'string | ComponentType<{}>'.
        Type 'ComponentClass<Attributes & { value: {}; children?: ComponentChildren; }, {}>' is not assignable to type 'ComponentClass<{}, {}>'.
          Types of parameters 'props' and 'props' are incompatible.
            Type '{}' is not assignable to type 'Attributes & { value: {}; children?: ComponentChildren; }'.
              Property 'value' is missing in type '{}' but required in type '{ value: {}; children?: ComponentChildren; }'.

6 renderToPipeableStream(h(Context.Provider, { value: {} }), {});
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/preact/src/index.d.ts:383:3
    383   value: T;
          ~~~~~
    'value' is declared here.
```

https://codesandbox.io/p/devbox/2tk3ws

Using the same fix as https://github.com/preactjs/preact-render-to-string/commit/3dcf09891b13190faed36f4d798e2adb9cd3e6fd for these functions solves it