### PR TITLE
Fix rendering waterfall of suspended components in a single Suspense boundary

### DIFF
--- a/.changeset/long-ties-brake.md
+++ b/.changeset/long-ties-brake.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Fix async rendering of multiple suspended components in a single Suspense boundary

--- a/src/index.js
+++ b/src/index.js
@@ -542,21 +542,8 @@ function _renderToString(
 						: result;
 				} catch (e) {
 					if (!e || typeof e.then != 'function') throw e;
-
-					return e.then(() => {
-						const result = _renderToString(
-							rendered,
-							context,
-							isSvgMode,
-							selectValue,
-							vnode,
-							asyncMode,
-							renderer
-						);
-						return vnode._suspended
-							? BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR
-							: result;
-					}, renderNestedChildren);
+					
+					return e.then(renderNestedChildren);
 				}
 			};
 


### PR DESCRIPTION
I ran into an issue that is very similar to https://github.com/preactjs/preact-render-to-string/pull/335, where multiple suspended children in the same Suspense boundary throw a promise that bubbles out of the render functions, resulting in `Error: the promise {} was thrown, throw an Error :)`.

```jsx
const promise = renderToStringAsync(
	<ul>
		<Suspense fallback={null}>
			<SuspenderOne>
				<li>one</li>
			</SuspenderOne>
			<SuspenderTwo>
				<li>two</li>
			</SuspenderTwo>
			<SuspenderThree>
				<li>three</li>
			</SuspenderThree>
		</Suspense>
	</ul>
);

suspendedOne.promise.then(() => { void suspendedTwo.resolve();});
suspendedTwo.promise.then(() => { void suspendedThree.resolve();});

suspendedOne.resolve();
```

This only occurs when there are 3+ direct children in a Suspense boundary, rendered async, where the Promises resolve one by one, which is why the test case added by #335 doesn't catch this.
Staggering the Promise resolves makes a key difference: with the existing test, rendering suspends on the Promise thrown in SuspenderOne, after which all three promises are resolved, and then rendering continues: SuspenderTwo and SuspenderThree never throw a promise.

https://github.com/preactjs/preact-render-to-string/blob/81e7da321da925dbd8eba345ecbd46b1cf456b69/src/index.js#L546-L559
The issue arises here due to the use of `.then(onFulfilled, onRejected)` instead of `.then(onFulfilled).catch(onRejected)`: when the onFulfilled callback throws an error here, it won't be caught.
But after changing that in the code (which makes all the tests pass) I realised that block could also be simplified to just
```js
const renderNestedChildren = () => {
	try {
		const result = _renderToString(
			rendered,
			context,
			isSvgMode,
			selectValue,
			vnode,
			asyncMode,
			renderer
		);
		return vnode._suspended
			? BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR
			: result;
	} catch (e) {
		if (!e || typeof e.then != 'function') throw e;
		
		return e.then(renderNestedChildren);
	}
};

return error.then(renderNestedChildren);
```
Without the additional inline closure.