### PR TITLE
fix: Only abort pipeablestream if not already closed

### DIFF
--- a/.changeset/yellow-hounds-jog.md
+++ b/.changeset/yellow-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Only abort/report errors from `renderToPipeableStream()` if the stream hasn't already been closed

--- a/src/stream-node.js
+++ b/src/stream-node.js
@@ -60,7 +60,14 @@ export function renderToPipeableStream(vnode, options, context) {
 		/**
 		 * @param {unknown} [reason]
 		 */
-		abort(reason = new Error('The render was aborted by the server without a reason.')) {
+		abort(
+			reason = new Error(
+				'The render was aborted by the server without a reason.'
+			)
+		) {
+			// Remix/React-Router will always call abort after a timeout, even on success
+			if (stream.closed) return;
+
 			controller.abort();
 			stream.destroy();
 			if (options.onError) {

--- a/test/compat/stream-node.test.js
+++ b/test/compat/stream-node.test.js
@@ -73,4 +73,19 @@ describe('renderToPipeableStream', () => {
 			'</div>'
 		]);
 	});
+
+	it('should not error if the stream has already been closed', async () => {
+		let error;
+		const sink = createSink();
+		const { pipe, abort } = renderToPipeableStream(<div class="foo">bar</div>, {
+			onAllReady: () => {
+				pipe(sink.stream);
+			},
+			onError: (e) => (error = e)
+		});
+		await sink.promise;
+		abort();
+
+		expect(error).to.be.undefined;
+	});
 });

--- a/test/compat/stream.test.js
+++ b/test/compat/stream.test.js
@@ -82,10 +82,10 @@ describe('renderToReadableStream', () => {
 		const result = await sink.promise;
 
 		expect(result).to.deep.equal([
-			'<div><!--preact-island:54-->loading...<!--/preact-island:54--></div>',
+			'<div><!--preact-island:56-->loading...<!--/preact-island:56--></div>',
 			'<div hidden>',
 			createInitScript(),
-			createSubtree('54', '<p>it works</p>'),
+			createSubtree('56', '<p>it works</p>'),
 			'</div>'
 		]);
 	});


### PR DESCRIPTION
Remix/React-Router seems to [always call `abort()` after a short timeout](https://github.com/remix-run/react-router/blob/5a1ca081ef49475ac9e23b6ea6ca6f365db58597/packages/react-router-dev/config/defaults/entry.server.node.tsx#L64-L66). This reports the following "error":

```
Error: The render was aborted by the server without a reason.
    at Timeout.abort [as _onTimeout] (file:///home/ryun/Projects/tmp-react-router-preact/node_modules/preact-render-to-string/src/stream-node.js:75:4)
    at listOnTimeout (node:internal/timers:594:17)
    at processTimers (node:internal/timers:529:7)
```

To my understanding, this is something we can ignore if the stream has already been closed. [React does something along these lines too](https://github.com/facebook/react/blob/a0fdb6306043b9f049106e58dcec107d8dbed2b1/packages/react-server/src/ReactFizzServer.js#L5352-L5353), checking to ensure there's tasks that can be aborted before throwing and cleaning up further.

cc @sbesh91