### PR TITLE
Preserve whitespace for pre/textarea when pretty-printing

### DIFF
--- a/.changeset/rude-apes-taste.md
+++ b/.changeset/rude-apes-taste.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Preserve whitespace in `<pre>`/`<textarea>` when using `pretty: true`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact-render-to-string",
-	"version": "6.5.13",
+	"version": "6.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact-render-to-string",
-			"version": "6.5.13",
+			"version": "6.6.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -32,7 +32,7 @@
 				"web-streams-polyfill": "^3.2.1"
 			},
 			"peerDependencies": {
-				"preact": ">=10 || >= 11"
+				"preact": ">=10 || >= 11.0.0-0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -13378,21 +13378,6 @@
 				}
 			}
 		},
-		"node_modules/vite-node/node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/vitest": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -13671,21 +13656,6 @@
 				"yaml": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vitest/node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
 			}
 		},
 		"node_modules/wcwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13378,6 +13378,21 @@
 				}
 			}
 		},
+		"node_modules/vite-node/node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			}
+		},
 		"node_modules/vitest": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -13656,6 +13671,21 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
 			}
 		},
 		"node_modules/wcwidth": {

--- a/test/pretty.test.jsx
+++ b/test/pretty.test.jsx
@@ -215,6 +215,25 @@ describe('pretty', () => {
 		);
 	});
 
+	it('should not add whitespace to pre tag children', () => {
+		let rendered = prettyRender(
+			<pre>
+				<code>hello</code>
+			</pre>,
+			{ jsx: false }
+		);
+
+		expect(rendered).to.equal(`<pre><code>hello</code></pre>`);
+	});
+
+	it('should maintain whitespace in textarea tag', () => {
+		let rendered = prettyRender(<textarea>{'  hello\nworld  '}</textarea>, {
+			jsx: false
+		});
+
+		expect(rendered).to.equal(`<textarea>  hello\nworld  </textarea>`);
+	});
+
 	describe('Attribute casing', () => {
 		it('should have correct SVG casing', () => {
 			for (let name in svgAttributes) {

--- a/test/render.test.jsx
+++ b/test/render.test.jsx
@@ -243,6 +243,13 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		it('should serialize textarea value with leading/trailing whitespace', () => {
+			let rendered = render(<textarea value={`  a\nb  `} />),
+				expected = `<textarea>  a\nb  </textarea>`;
+
+			expect(rendered).to.equal(expected);
+		});
+
 		it('should escape textarea value', () => {
 			let rendered = render(<textarea value={`a&b"c`} />),
 				expected = `<textarea>a&amp;b&quot;c</textarea>`;


### PR DESCRIPTION
`<pre>` and `<textarea>` are whitespace-sensitive. When pretty-printing, it's important to not inject extra whitespace when rendering them.

There may be more tags for which whitespace should be preserved; these are the two that I specifically know about.

Disclosure: I wrote the tests by hand and used GPT-5-Codex to help with the implementation.