### PR TITLE
Ensure we can suspend from a given component more than once

### DIFF
--- a/.changeset/heavy-sloths-cry.md
+++ b/.changeset/heavy-sloths-cry.md
@@ -1,0 +1,5 @@
+---
+'preact-render-to-string': patch
+---
+
+Ensure that in streaming mode throwing a suspension multiple times from the same component works


### PR DESCRIPTION
Resolves https://github.com/preactjs/preact-render-to-string/issues/435

The issue was that we start rendering again from the same component which means there was no outer try-catch block to rely on. To fix this we don't start rendering from the parent, else we might break `useId` allocation, we resume from the same child but make onError recursive.