### PR TITLE
fix: use `export =` instead of esm exports for jsx export types

### DIFF
--- a/.changeset/gentle-eyes-trade.md
+++ b/.changeset/gentle-eyes-trade.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+fix: use cjs types instead of esm for jsx export to fix default export from esm

--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -10,15 +10,24 @@ interface Options {
 	skipFalseAttributes?: boolean;
 }
 
-export default function renderToStringPretty(
+declare function renderToStringPretty(
 	vnode: VNode,
 	context?: any,
 	options?: Options
 ): string;
-export function render(vnode: VNode, context?: any, options?: Options): string;
 
-export function shallowRender(
-	vnode: VNode,
-	context?: any,
-	options?: Options
-): string;
+declare namespace renderToStringPretty {
+	export function render(
+		vnode: VNode,
+		context?: any,
+		options?: Options
+	): string;
+
+	export function shallowRender(
+		vnode: VNode,
+		context?: any,
+		options?: Options
+	): string;
+}
+
+export = renderToStringPretty;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -10,15 +10,24 @@ interface Options {
 	skipFalseAttributes?: boolean;
 }
 
-export default function renderToStringPretty(
+declare function renderToStringPretty(
 	vnode: VNode,
 	context?: any,
 	options?: Options
 ): string;
-export function render(vnode: VNode, context?: any, options?: Options): string;
 
-export function shallowRender(
-	vnode: VNode,
-	context?: any,
-	options?: Options
-): string;
+declare namespace renderToStringPretty {
+	export function render(
+		vnode: VNode,
+		context?: any,
+		options?: Options
+	): string;
+
+	export function shallowRender(
+		vnode: VNode,
+		context?: any,
+		options?: Options
+	): string;
+}
+
+export = renderToStringPretty;


### PR DESCRIPTION
Not sure what's up with this file appearing twice (probably compat for before exports existed? Is it still worth having?), but this is a hacky fix for the default export being wrong.

The fix is to just write the declaration files using `export =` instead of esm exports because typescript resolves these as cjs. This makes the package work now when imported from ESM.

<img width="842" height="227" alt="image" src="https://github.com/user-attachments/assets/1d96395f-7f97-4a8b-a218-041e613f77d5" />

Closes #443
