### PR TITLE
fix: renderToStringAsync produces commas for suspended components with complex children

### DIFF
--- a/.changeset/witty-goats-repair.md
+++ b/.changeset/witty-goats-repair.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+fix: renderToStringAsync produces commas for suspended components with complex children

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,25 @@ const EMPTY_STR = '';
 const BEGIN_SUSPENSE_DENOMINATOR = '<!--$s-->';
 const END_SUSPENSE_DENOMINATOR = '<!--/$s-->';
 
+/**
+ * Wraps a render result with suspense boundary markers, handling all possible
+ * return types from _renderToString: string, Array, or Promise.
+ * @param {string | Array | Promise} result
+ * @returns {string | Array | Promise}
+ */
+function wrapWithSuspenseMarkers(result) {
+	if (typeof result === 'string') {
+		return BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR;
+	} else if (isArray(result)) {
+		result.unshift(BEGIN_SUSPENSE_DENOMINATOR);
+		result.push(END_SUSPENSE_DENOMINATOR);
+		return result;
+	} else if (result && typeof result.then === 'function') {
+		return result.then(wrapWithSuspenseMarkers);
+	}
+	return BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR;
+}
+
 // Global state for the current render pass
 let beforeDiff, afterDiff, renderHook, ummountHook;
 
@@ -498,18 +517,7 @@ function _renderToString(
 			if (options.unmount) options.unmount(vnode);
 
 			if (vnode._suspended) {
-				if (typeof str === 'string') {
-					return BEGIN_SUSPENSE_DENOMINATOR + str + END_SUSPENSE_DENOMINATOR;
-				} else if (isArray(str)) {
-					str.unshift(BEGIN_SUSPENSE_DENOMINATOR);
-					str.push(END_SUSPENSE_DENOMINATOR);
-					return str;
-				}
-
-				return str.then(
-					(resolved) =>
-						BEGIN_SUSPENSE_DENOMINATOR + resolved + END_SUSPENSE_DENOMINATOR
-				);
+				return wrapWithSuspenseMarkers(str);
 			}
 
 			return str;
@@ -556,9 +564,7 @@ function _renderToString(
 						asyncMode,
 						renderer
 					);
-					return vnode._suspended
-						? BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR
-						: result;
+					return vnode._suspended ? wrapWithSuspenseMarkers(result) : result;
 				} catch (e) {
 					if (!e || typeof e.then != 'function') throw e;
 

--- a/test/compat/async.test.jsx
+++ b/test/compat/async.test.jsx
@@ -360,6 +360,82 @@ describe('Async renderToString', () => {
 		);
 	});
 
+	it('should not produce commas or [object Promise] when cascading suspensions produce array results', async () => {
+		// Regression: when component A suspends then re-renders with children
+		// that also suspend at multiple levels (B→C→D), the .then() handler
+		// wrapping suspended output receives an Array instead of a string.
+		// String concatenation with an Array calls Array.toString(), injecting
+		// commas into the HTML.
+		let aResolved = false;
+		const aPromise = new Promise((r) =>
+			setTimeout(() => {
+				aResolved = true;
+				r();
+			}, 5)
+		);
+
+		let cResolved = false;
+		const cPromise = new Promise((r) =>
+			setTimeout(() => {
+				cResolved = true;
+				r();
+			}, 15)
+		);
+
+		let dResolved = false;
+		const dPromise = new Promise((r) =>
+			setTimeout(() => {
+				dResolved = true;
+				r();
+			}, 25)
+		);
+
+		function A() {
+			if (!aResolved) throw aPromise;
+			return <B />;
+		}
+
+		function B() {
+			return (
+				<div>
+					<p>b-content</p>
+					<C />
+					<p>b-footer</p>
+				</div>
+			);
+		}
+
+		function C() {
+			if (!cResolved) throw cPromise;
+			return (
+				<Fragment>
+					<span>c-before</span>
+					<D />
+					<span>c-after</span>
+				</Fragment>
+			);
+		}
+
+		function D() {
+			if (!dResolved) throw dPromise;
+			return <em>d-content</em>;
+		}
+
+		const rendered = await renderToStringAsync(
+			<Suspense fallback={null}>
+				<A />
+			</Suspense>
+		);
+
+		expect(rendered).not.to.contain(',');
+		expect(rendered).not.to.contain('[object Promise]');
+		expect(rendered).to.contain('<p>b-content</p>');
+		expect(rendered).to.contain('<span>c-before</span>');
+		expect(rendered).to.contain('<em>d-content</em>');
+		expect(rendered).to.contain('<span>c-after</span>');
+		expect(rendered).to.contain('<p>b-footer</p>');
+	});
+
 	describe('dangerouslySetInnerHTML', () => {
 		it('should support dangerouslySetInnerHTML', async () => {
 			// some invalid HTML to make sure we're being flakey:


### PR DESCRIPTION
## Fix: `renderToStringAsync` produces commas and `[object Promise]` for suspended components with complex children

### Problem

When using `renderToStringAsync` with `<Suspense>` boundaries, certain component trees produce corrupted HTML output containing commas and `[object Promise]` literals. For example, rendered output may contain:

```
,,,,,[object Promise],
```

instead of the expected HTML.

### Root cause

Internally, `_renderToString` can return three types of values:

- `string` — when all children resolve to plain text
- `Array` — when children contain a mix of strings and pending Promises (e.g. nested elements with further suspensions)
- `Promise` — when a child threw a Promise (suspension)

The suspense marker wrapping code at two locations assumed the result was always a **string** and used `+` concatenation to wrap it with `<!--$s-->` / `<!--/$s-->` markers. When the result is an `Array`, JavaScript's `+` operator calls `Array.prototype.toString()`, which joins elements with commas — injecting comma characters into the HTML. When the result is a `Promise`, it produces the literal string `[object Promise]`.

### How to reproduce

The bug requires **multi-level cascading suspensions**: component A throws a Promise, and after resolving, its render tree contains components B, C, D that also throw independent Promises at different times. The key conditions:

1. Component A suspends (throws a Promise) → `A._suspended = true`
2. After A resolves, A re-renders and returns a single child B (through a Fragment)
3. B renders children containing C, which also throws a different Promise
4. C's catch handler returns a Promise, making `str` at A's level a `Promise`
5. Since `A._suspended` is true, the code enters `str.then((resolved) => N + resolved + q)`
6. When C resolves, its children contain D which also throws, creating arrays with Promises in the HTML element's child list
7. The `resolved` value in A's `.then()` callback is an `Array`, not a string
8. `N + Array + q` calls `Array.toString()` → **commas in the HTML output**

```jsx
function A() {
  if (!aResolved) throw aPromise;
  return <B />;
}
function B() {
  return (
    <div>
      <p>content</p>
      <C />
      <p>footer</p>
    </div>
  );
}
function C() {
  if (!cResolved) throw cPromise;
  return (
    <Fragment>
      <span>c</span>
      <D />
    </Fragment>
  );
}
function D() {
  if (!dResolved) throw dPromise;
  return <em>d</em>;
}

const rendered = await renderToStringAsync(
  <Suspense fallback={null}>
    <A />
  </Suspense>,
);
// Without fix: "<!--$s--><div>,,,,<p>content</p>,[object Promise],<p>footer</p>,</div><!--/$s-->"
// With fix:    "<!--$s--><div><p>content</p><!--$s--><span>c</span><!--$s--><em>d</em><!--/$s--><!--/$s--><p>footer</p></div><!--/$s-->"
```

### Fix

Extract a helper that handles all three return types — `string`, `Array`, and `Promise` — using the same pattern already present in the synchronous path.