### PR TITLE
ci: harden trusted publish workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request review for GitHub configuration changes.
+.github/ @JoviDeCroock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version: 22
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
@@ -72,6 +73,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Explicitly disables setup-node package-manager auto-caching in the trusted publishing workflow.
- Removes existing publish-workflow dependency cache usage where present.
- Pins external GitHub Actions in the trusted publish workflow to full commit SHAs, keeping the original tag as a comment breadcrumb.
- Adds CODEOWNERS for GitHub configuration changes.

## Why
Trusted publishing/OIDC workflows should not restore shared dependency caches, and tag-based action references can be retargeted after compromise. The StepSecurity advisory for `actions-cool/issues-helper` is the concrete failure mode: tags were moved to an imposter commit, while full-SHA pinned workflows were unaffected.

CODEOWNERS makes future `.github/` changes route to an explicit owner for review.

## Verification
- Rebases cleanly on `main`.
- `Build & Test` passes on the latest PR head.
- Parsed the edited workflow YAML locally with PyYAML.
- Re-scanned release workflow `uses:` entries and confirmed all external actions are pinned to 40-character commit SHAs.
- Confirmed no release workflow dependency cache remains: no `actions/cache@`, no setup-node `cache:`, and setup-node has `package-manager-cache: false`.