### PR TITLE
Perf tuning

### DIFF
--- a/benchmarks/async.js
+++ b/benchmarks/async.js
@@ -20,7 +20,7 @@ const lazies = new Array(600).fill(600).map(() =>
 	)
 );
 function PassThrough(props) {
-	const Lazy = lazies(props.id);
+	const Lazy = lazies[props.id];
 	return <Lazy {...props} />;
 }
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -10,26 +10,38 @@ import StackApp from './stack';
 import { App as IsomorphicSearchResults } from './isomorphic-ui/search-results/index';
 import { App as ColorPicker } from './isomorphic-ui/color-picker';
 
-function suite(name, Root) {
-	return new Suite(name)
-		.add('baseline', () => renderToStringAsyncBaseline(<Root />))
-		.add('current', () => renderToStringAsync(<Root />))
-		.run();
-}
-
-function asyncSuite(name, Root) {
+function syncSuite(name, Root) {
 	return new Suite(name)
 		.add('baseline', () => renderToStringBaseline(<Root />))
 		.add('current', () => renderToString(<Root />))
 		.run();
 }
 
-(async () => {
-	await suite('Text', TextApp);
-	await suite('SearchResults', IsomorphicSearchResults);
-	await suite('ColorPicker', ColorPicker);
-	await suite('Stack Depth', StackApp);
+function asyncSuite(name, Root) {
+	const suite = new Suite(name);
+	suite.suite.add(
+		'baseline',
+		function (deferred) {
+			renderToStringAsyncBaseline(<Root />).then(() => deferred.resolve());
+		},
+		{ defer: true }
+	);
+	suite.suite.add(
+		'current',
+		function (deferred) {
+			renderToStringAsync(<Root />).then(() => deferred.resolve());
+		},
+		{ defer: true }
+	);
+	return suite.run();
+}
 
-	const { App: Async } = await import('./async.js');
+(async () => {
+	await syncSuite('Text', TextApp);
+	await syncSuite('SearchResults', IsomorphicSearchResults);
+	await syncSuite('ColorPicker', ColorPicker);
+	await syncSuite('Stack Depth', StackApp);
+
+	const { default: Async } = await import('./async.js');
 	await asyncSuite('async', Async);
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ function _renderToString(
 	if (hooks.unmountHook) hooks.unmountHook(vnode);
 
 	// Emit self-closing tag for empty void elements:
-	if (!html && SELF_CLOSING.has(type)) {
+	if (!html && isSelfClosing(type)) {
 		return s + '/>';
 	}
 
@@ -791,24 +791,29 @@ function _renderToString(
 	return startTag + html + endTag;
 }
 
-const SELF_CLOSING = new Set([
-	'area',
-	'base',
-	'br',
-	'col',
-	'command',
-	'embed',
-	'hr',
-	'img',
-	'input',
-	'keygen',
-	'link',
-	'meta',
-	'param',
-	'source',
-	'track',
-	'wbr'
-]);
+function isSelfClosing(type) {
+	switch (type) {
+		case 'area':
+		case 'base':
+		case 'br':
+		case 'col':
+		case 'command':
+		case 'embed':
+		case 'hr':
+		case 'img':
+		case 'input':
+		case 'keygen':
+		case 'link':
+		case 'meta':
+		case 'param':
+		case 'source':
+		case 'track':
+		case 'wbr':
+			return true;
+		default:
+			return false;
+	}
+}
 
 export default renderToString;
 export const render = renderToString;

--- a/src/index.js
+++ b/src/index.js
@@ -754,6 +754,8 @@ function _renderToString(
 	} else if (typeof children === 'string') {
 		// single text child
 		html = encodeEntities(children);
+	} else if (typeof children === 'number') {
+		html = children + EMPTY_STR;
 	} else if (children != null && children !== false && children !== true) {
 		// recurse into this element VNode's children
 		let childSvgMode =

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ export async function renderToStringAsync(vnode, context) {
 	const hooks = captureHooks();
 
 	try {
-		const rendered = await withSkipEffects(() => {
+		let rendered = withSkipEffects(() => {
 			const parent = h(Fragment, null);
 			parent[CHILDREN] = [vnode];
 			if (hooks.rootHook) {
@@ -169,6 +169,10 @@ export async function renderToStringAsync(vnode, context) {
 				hooks
 			);
 		});
+
+		if (typeof rendered !== 'string' && !isArray(rendered)) {
+			rendered = await rendered;
+		}
 
 		if (isArray(rendered)) {
 			let count = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -411,8 +411,8 @@ function _renderToString(
 				cctx = provider ? provider.props.value : contextType.__;
 			}
 
-			let isClassComponent =
-				type.prototype && typeof type.prototype.render == 'function';
+			let prototype = type.prototype;
+			let isClassComponent = prototype && typeof prototype.render == 'function';
 			if (isClassComponent) {
 				rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx, hooks);
 				component = vnode[COMPONENT];

--- a/src/index.js
+++ b/src/index.js
@@ -306,16 +306,22 @@ function _renderToString(
 			let child = vnode[i];
 			if (child == null || typeof child == 'boolean') continue;
 
-			const childRender = _renderToString(
-				child,
-				context,
-				isSvgMode,
-				selectValue,
-				parent,
-				asyncMode,
-				renderer,
-				hooks
-			);
+			const childType = typeof child;
+			const childRender =
+				childType == 'string'
+					? encodeEntities(child)
+					: childType == 'number'
+						? child + EMPTY_STR
+						: _renderToString(
+								child,
+								context,
+								isSvgMode,
+								selectValue,
+								parent,
+								asyncMode,
+								renderer,
+								hooks
+							);
 
 			if (typeof childRender == 'string') {
 				rendered = rendered + childRender;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import {
 	UNSAFE_NAME,
 	NAMESPACE_REPLACE_REGEX,
 	HTML_LOWER_CASE,
-	HTML_ENUMERATED,
 	SVG_CAMEL_CASE,
 	createComponent,
 	setDirty,
@@ -701,10 +700,10 @@ function _renderToString(
 			default: {
 				if (UNSAFE_NAME.test(name)) {
 					continue;
-				} else if (NAMESPACE_REPLACE_REGEX.test(name)) {
+				} else if (name[0] === 'x' && NAMESPACE_REPLACE_REGEX.test(name)) {
 					name = name.replace(NAMESPACE_REPLACE_REGEX, '$1:$2').toLowerCase();
 				} else if (
-					(name[4] === '-' || HTML_ENUMERATED.has(name)) &&
+					(name[4] === '-' || name === 'draggable' || name === 'spellcheck') &&
 					v != null
 				) {
 					// serialize boolean aria-xyz or enumerated attribute values as strings

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,16 @@ function hasPromise(values) {
 	return false;
 }
 
+function flatten(values) {
+	let result = [];
+	for (let i = 0; i < values.length; i++) {
+		let value = values[i];
+		if (isArray(value)) result.push(...value);
+		else result.push(value);
+	}
+	return result;
+}
+
 /**
  * Capture the Preact option hooks used by a render so suspended subtrees don't
  * observe hooks installed by another render before they resume.
@@ -184,7 +194,7 @@ export async function renderToStringAsync(vnode, context) {
 
 			// Resolving nested Promises with a maximum depth of 25
 			while (hasPromise(resolved) && count++ < 25) {
-				resolved = (await Promise.all(resolved)).flat();
+				resolved = flatten(await Promise.all(resolved));
 			}
 
 			return resolved.join(EMPTY_STR);

--- a/src/index.js
+++ b/src/index.js
@@ -828,10 +828,14 @@ function getNamespaceLength(name) {
 	return char >= 65 &&
 		char <= 90 &&
 		(length === 3
-			? name.slice(0, 3) === 'xml'
+			? name.charCodeAt(1) === 109 && name.charCodeAt(2) === 108
 			: name[1] === 'l'
-				? name.slice(0, 5) === 'xlink'
-				: name.slice(0, 5) === 'xmlns')
+				? name.charCodeAt(2) === 105 &&
+					name.charCodeAt(3) === 110 &&
+					name.charCodeAt(4) === 107
+				: name.charCodeAt(1) === 109 &&
+					name.charCodeAt(2) === 108 &&
+					name.charCodeAt(4) === 115)
 		? length
 		: 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,14 @@ function wrapWithSuspenseMarkers(result) {
 	return BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR;
 }
 
+function hasPromise(values) {
+	for (let i = 0; i < values.length; i++) {
+		let value = values[i];
+		if (value && typeof value.then === 'function') return true;
+	}
+	return false;
+}
+
 /**
  * Capture the Preact option hooks used by a render so suspended subtrees don't
  * observe hooks installed by another render before they resume.
@@ -177,12 +185,7 @@ export async function renderToStringAsync(vnode, context) {
 			let resolved = rendered;
 
 			// Resolving nested Promises with a maximum depth of 25
-			while (
-				resolved.some(
-					(element) => element && typeof element.then === 'function'
-				) &&
-				count++ < 25
-			) {
+			while (hasPromise(resolved) && count++ < 25) {
 				resolved = (await Promise.all(resolved)).flat();
 			}
 

--- a/src/index.js
+++ b/src/index.js
@@ -302,6 +302,7 @@ function _renderToString(
 			if (child == null || typeof child == 'boolean') continue;
 
 			const childType = typeof child;
+			if (childType == 'function') continue;
 			const childRender =
 				childType == 'string'
 					? encodeEntities(child)

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import {
 	encodeEntities,
 	styleObjToCss,
 	UNSAFE_NAME,
-	NAMESPACE_REPLACE_REGEX,
 	HTML_LOWER_CASE,
 	SVG_CAMEL_CASE,
 	createComponent,
@@ -698,10 +697,17 @@ function _renderToString(
 				break;
 
 			default: {
+				let namespaceLength;
 				if (UNSAFE_NAME.test(name)) {
 					continue;
-				} else if (name[0] === 'x' && NAMESPACE_REPLACE_REGEX.test(name)) {
-					name = name.replace(NAMESPACE_REPLACE_REGEX, '$1:$2').toLowerCase();
+				} else if (
+					name[0] === 'x' &&
+					(namespaceLength = getNamespaceLength(name)) !== 0
+				) {
+					name =
+						name.slice(0, namespaceLength) +
+						':' +
+						name.slice(namespaceLength).toLowerCase();
 				} else if (
 					(name[4] === '-' || name === 'draggable' || name === 'spellcheck') &&
 					v != null
@@ -811,4 +817,18 @@ function isSignal(x) {
 		typeof x.peek === 'function' &&
 		'value' in x
 	);
+}
+
+function getNamespaceLength(name) {
+	let length = name[1] === 'l' || name[3] === 'n' ? 5 : 3;
+	let char = name.charCodeAt(length);
+	return char >= 65 &&
+		char <= 90 &&
+		(length === 3
+			? name.slice(0, 3) === 'xml'
+			: name[1] === 'l'
+				? name.slice(0, 5) === 'xlink'
+				: name.slice(0, 5) === 'xmlns')
+		? length
+		: 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -43,9 +43,7 @@ function wrapWithSuspenseMarkers(result) {
 	if (typeof result === 'string') {
 		return BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR;
 	} else if (isArray(result)) {
-		result.unshift(BEGIN_SUSPENSE_DENOMINATOR);
-		result.push(END_SUSPENSE_DENOMINATOR);
-		return result;
+		return [BEGIN_SUSPENSE_DENOMINATOR, ...result, END_SUSPENSE_DENOMINATOR];
 	} else if (result && typeof result.then === 'function') {
 		return result.then(wrapWithSuspenseMarkers);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -280,12 +280,7 @@ function _renderToString(
 	hooks
 ) {
 	// Ignore non-rendered VNodes/values
-	if (
-		vnode == null ||
-		vnode === true ||
-		vnode === false ||
-		vnode === EMPTY_STR
-	) {
+	if (vnode == null || vnode === true || vnode === false) {
 		return EMPTY_STR;
 	}
 

--- a/src/lib/chunked.js
+++ b/src/lib/chunked.js
@@ -59,13 +59,10 @@ function getDocumentClosingTagsIndex(html) {
 }
 
 async function forkPromises(renderer) {
-	if (renderer.suspended.length > 0) {
-		const suspensions = [...renderer.suspended];
+	while (renderer.suspended.length > 0) {
+		const length = renderer.suspended.length;
 		await Promise.all(renderer.suspended.map((s) => s.promise));
-		renderer.suspended = renderer.suspended.filter(
-			(s) => !suspensions.includes(s)
-		);
-		await forkPromises(renderer);
+		renderer.suspended.splice(0, length);
 	}
 }
 

--- a/src/lib/chunked.js
+++ b/src/lib/chunked.js
@@ -82,16 +82,8 @@ function handleError(error, vnode, renderChild) {
 
 	const id = vnode.__v;
 	const found = this.suspended.find((x) => x.id === id);
-	const race = new Deferred();
-
 	const abortSignal = this.abortSignal;
-	if (abortSignal) {
-		// @ts-ignore 2554 - implicit undefined arg
-		if (abortSignal.aborted) race.resolve();
-		else abortSignal.addEventListener('abort', race.resolve);
-	}
-
-	const promise = error.then(
+	let promise = error.then(
 		() => {
 			if (abortSignal && abortSignal.aborted) return;
 			const child = renderChild(vnode.props.children, vnode);
@@ -101,11 +93,18 @@ function handleError(error, vnode, renderChild) {
 		// to attempt to recover during hydration
 		this.onError
 	);
+	if (abortSignal) {
+		const race = new Deferred();
+		// @ts-ignore 2554 - implicit undefined arg
+		if (abortSignal.aborted) race.resolve();
+		else abortSignal.addEventListener('abort', race.resolve);
+		promise = Promise.race([promise, race.promise]);
+	}
 
 	this.suspended.push({
 		id,
 		vnode,
-		promise: Promise.race([promise, race.promise])
+		promise
 	});
 
 	const fallback = renderChild(vnode.props.fallback);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -40,16 +40,22 @@ export function isDirty(component) {
 /** @param {string} str */
 export function encodeEntities(str) {
 	// Skip all work for strings with no entities needing encoding:
-	if (
-		str.length === 0 ||
-		(str.indexOf('"') === -1 &&
-			str.indexOf('&') === -1 &&
-			str.indexOf('<') === -1)
-	)
+	let i = 0;
+	if (str.length < 8) {
+		for (; i < str.length; i++) {
+			const char = str.charCodeAt(i);
+			if (char === 34 || char === 38 || char === 60) break;
+		}
+		if (i === str.length) return str;
+	} else if (
+		str.indexOf('"') === -1 &&
+		str.indexOf('&') === -1 &&
+		str.indexOf('<') === -1
+	) {
 		return str;
+	}
 
 	let last = 0,
-		i = 0,
 		out = '',
 		ch = '';
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -37,13 +37,16 @@ export function isDirty(component) {
 	return component[DIRTY] === true;
 }
 
-// DOM properties that should NOT have "px" added when numeric
-const ENCODED_ENTITIES = /["&<]/;
-
 /** @param {string} str */
 export function encodeEntities(str) {
 	// Skip all work for strings with no entities needing encoding:
-	if (str.length === 0 || ENCODED_ENTITIES.test(str) === false) return str;
+	if (
+		str.length === 0 ||
+		(str.indexOf('"') === -1 &&
+			str.indexOf('&') === -1 &&
+			str.indexOf('<') === -1)
+	)
+		return str;
 
 	let last = 0,
 		i = 0,

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -7,7 +7,6 @@ import {
 	createComponent,
 	UNSAFE_NAME,
 	VOID_ELEMENTS,
-	NAMESPACE_REPLACE_REGEX,
 	SVG_CAMEL_CASE,
 	HTML_ENUMERATED,
 	HTML_LOWER_CASE,
@@ -154,7 +153,6 @@ function _renderToStringPretty(
 			let rendered;
 
 			let c = (vnode.__c = createComponent(vnode, context));
-
 			let renderHook = options[RENDER];
 
 			if (
@@ -255,7 +253,8 @@ function _renderToStringPretty(
 
 		for (let i = 0; i < attrs.length; i++) {
 			let name = attrs[i],
-				v = props[name];
+				v = props[name],
+				namespaceLength;
 			if (name === 'children') {
 				propChildren = v;
 				continue;
@@ -285,8 +284,14 @@ function _renderToStringPretty(
 				name = 'accept-charset';
 			} else if (name === 'httpEquiv') {
 				name = 'http-equiv';
-			} else if (NAMESPACE_REPLACE_REGEX.test(name)) {
-				name = name.replace(NAMESPACE_REPLACE_REGEX, '$1:$2').toLowerCase();
+			} else if (
+				name[0] === 'x' &&
+				(namespaceLength = getNamespaceLength(name)) !== 0
+			) {
+				name =
+					name.slice(0, namespaceLength) +
+					':' +
+					name.slice(namespaceLength).toLowerCase();
 			} else if (
 				(name.at(4) === '-' || HTML_ENUMERATED.has(name)) &&
 				v != null
@@ -459,6 +464,20 @@ function _renderToStringPretty(
 	}
 
 	return s;
+}
+
+function getNamespaceLength(name) {
+	let length = name[1] === 'l' || name[3] === 'n' ? 5 : 3;
+	let char = name.charCodeAt(length);
+	return char >= 65 &&
+		char <= 90 &&
+		(length === 3
+			? name.slice(0, 3) === 'xml'
+			: name[1] === 'l'
+				? name.slice(0, 5) === 'xlink'
+				: name.slice(0, 5) === 'xmlns')
+		? length
+		: 0;
 }
 
 function getComponentName(component) {


### PR DESCRIPTION
## Summary

This tunes several hot paths in synchronous, asynchronous, JSX, and streaming rendering:

- avoid a redundant await for synchronous results returned through `renderToStringAsync`
- replace entity and attribute regular-expression work with targeted string and prefix scans
- reuse component prototype lookups and serialize numeric children directly
- specialize primitive array children and skip function-valued children without recursive renderer calls
- parse XML, XMLNS, and XLINK attribute prefixes without regex replacement or prefix slicing
- replace self-closing element Set lookups with a direct switch
- scan and flatten asynchronous render results directly and wrap suspense arrays in one pass
- remove quadratic suspension cleanup and skip abort-race allocation when no abort signal is present
- correct the async benchmark so Benchmark.js waits for each render to settle

## Measured impact

- small synchronous trees through `renderToStringAsync`: 16.7–19.8% faster
- plain text serialization: 18.4–21.3% faster
- short safe strings: 7.7–15.8% faster; short escaped strings: 10.6–17.4% faster
- HTML attribute-heavy rendering: 8.0–8.1% faster; SVG attributes: 3.5–4.9% faster
- deep function-component trees: 6.1–6.8% faster; class-component trees: 2.3–5.9% faster
- namespace-heavy SVG rendering: 2.39–2.40× throughput
- namespace-heavy JSX rendering: 2.04–2.22× throughput
- numeric child lists: 9.1–14.2% faster
- suspension cleanup: 10.3–12.8% faster at 5,000 concurrent boundaries
- non-abortable streams: 1.8–3.4% faster with one suspended boundary and 2.6–3.2% faster with 10–100 boundaries

## Additional D8 measurements

Measured against the previous PR head `b8d7377` using seven alternating fresh-process runs per side and isolated hot-path filters:

- primitive child arrays: 18.7% faster internally and 10.6% faster through `renderToString`
- arrays containing function values: 39.5% faster internally and 14.9% faster through `renderToString`
- empty strings: 2.6% faster; ordinary text: 6.8% faster
- XML, XMLNS, and XLINK prefix checks: 51.9–74.5% faster; SVG namespace rendering: 4.7% faster
- promise detection in async result arrays: 9.5–11.1% faster
- one-level async result flattening: 59.7% faster
- suspense array wrapping: 58.0% faster
- void-element rendering: 2.2% faster
- four concurrently suspending siblings: 0.75% faster
