### PR TITLE
Isolate Preact options during async renders

### DIFF
--- a/.changeset/tidy-ravens-render.md
+++ b/.changeset/tidy-ravens-render.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+Keep Preact option hooks isolated for the lifetime of asynchronous renders.

--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,9 @@ function wrapWithSuspenseMarkers(result) {
 /**
  * Capture the Preact option hooks used by a render so suspended subtrees don't
  * observe hooks installed by another render before they resume.
- * @returns {RenderState}
+ * @returns {CapturedHooks}
  */
-function createRenderState() {
+function captureHooks() {
 	return {
 		beforeDiff: options[DIFF],
 		afterDiff: options[DIFFED],
@@ -99,14 +99,14 @@ function withSkipEffects(render) {
  * @returns {string} serialized HTML
  */
 export function renderToString(vnode, context, _rendererState) {
-	const renderState = createRenderState();
+	const hooks = captureHooks();
 
 	try {
 		const rendered = withSkipEffects(() => {
 			const parent = h(Fragment, null);
 			parent[CHILDREN] = [vnode];
-			if (renderState.rootHook) {
-				renderState.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
+			if (hooks.rootHook) {
+				hooks.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
 			}
 
 			return _renderToString(
@@ -117,7 +117,7 @@ export function renderToString(vnode, context, _rendererState) {
 				parent,
 				false,
 				_rendererState,
-				renderState
+				hooks
 			);
 		});
 
@@ -134,8 +134,8 @@ export function renderToString(vnode, context, _rendererState) {
 	} finally {
 		// options._commit, we don't schedule any effects in this library right now,
 		// so we can pass an empty queue to this hook.
-		if (renderState.commitHook) {
-			withSkipEffects(() => renderState.commitHook(vnode, EMPTY_ARR));
+		if (hooks.commitHook) {
+			withSkipEffects(() => hooks.commitHook(vnode, EMPTY_ARR));
 		}
 		EMPTY_ARR.length = 0;
 	}
@@ -148,14 +148,14 @@ export function renderToString(vnode, context, _rendererState) {
  * @returns {string} serialized HTML
  */
 export async function renderToStringAsync(vnode, context) {
-	const renderState = createRenderState();
+	const hooks = captureHooks();
 
 	try {
 		const rendered = await withSkipEffects(() => {
 			const parent = h(Fragment, null);
 			parent[CHILDREN] = [vnode];
-			if (renderState.rootHook) {
-				renderState.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
+			if (hooks.rootHook) {
+				hooks.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
 			}
 
 			return _renderToString(
@@ -166,7 +166,7 @@ export async function renderToStringAsync(vnode, context) {
 				parent,
 				true,
 				undefined,
-				renderState
+				hooks
 			);
 		});
 
@@ -191,8 +191,8 @@ export async function renderToStringAsync(vnode, context) {
 	} finally {
 		// options._commit, we don't schedule any effects in this library right now,
 		// so we can pass an empty queue to this hook.
-		if (renderState.commitHook) {
-			withSkipEffects(() => renderState.commitHook(vnode, EMPTY_ARR));
+		if (hooks.commitHook) {
+			withSkipEffects(() => hooks.commitHook(vnode, EMPTY_ARR));
 		}
 		EMPTY_ARR.length = 0;
 	}
@@ -201,9 +201,9 @@ export async function renderToStringAsync(vnode, context) {
 /**
  * @param {VNode} vnode
  * @param {Record<string, unknown>} context
- * @param {RenderState} renderState
+ * @param {CapturedHooks} hooks
  */
-function renderClassComponent(vnode, context, renderState) {
+function renderClassComponent(vnode, context, hooks) {
 	let type =
 		/** @type {import("preact").ComponentClass<typeof vnode.props>} */ (
 			vnode.type
@@ -250,7 +250,7 @@ function renderClassComponent(vnode, context, renderState) {
 		c.componentWillUpdate();
 	}
 
-	if (renderState.renderHook) renderState.renderHook(vnode);
+	if (hooks.renderHook) hooks.renderHook(vnode);
 
 	return c.render(c.props, c.state, context);
 }
@@ -264,7 +264,7 @@ function renderClassComponent(vnode, context, renderState) {
  * @param {VNode} parent
  * @param {boolean} asyncMode
  * @param {RendererState | undefined | false} renderer
- * @param {RenderState} renderState
+ * @param {CapturedHooks} hooks
  * @returns {string | Promise<string> | (string | Promise<string>)[]}
  */
 function _renderToString(
@@ -275,7 +275,7 @@ function _renderToString(
 	parent,
 	asyncMode,
 	renderer,
-	renderState
+	hooks
 ) {
 	// Ignore non-rendered VNodes/values
 	if (
@@ -312,7 +312,7 @@ function _renderToString(
 				parent,
 				asyncMode,
 				renderer,
-				renderState
+				hooks
 			);
 
 			if (typeof childRender == 'string') {
@@ -347,7 +347,7 @@ function _renderToString(
 	if (vnode.constructor !== undefined) return EMPTY_STR;
 
 	vnode[PARENT] = parent;
-	if (renderState.beforeDiff) renderState.beforeDiff(vnode);
+	if (hooks.beforeDiff) hooks.beforeDiff(vnode);
 
 	let type = vnode.type,
 		props = vnode.props;
@@ -384,7 +384,7 @@ function _renderToString(
 									vnode,
 									asyncMode,
 									renderer,
-									renderState
+									hooks
 								);
 						} else {
 							// Values are pre-escaped by the JSX transform
@@ -411,11 +411,7 @@ function _renderToString(
 			let isClassComponent =
 				type.prototype && typeof type.prototype.render == 'function';
 			if (isClassComponent) {
-				rendered = /**#__NOINLINE__**/ renderClassComponent(
-					vnode,
-					cctx,
-					renderState
-				);
+				rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx, hooks);
 				component = vnode[COMPONENT];
 			} else {
 				vnode[COMPONENT] = component = /**#__NOINLINE__**/ createComponent(
@@ -432,7 +428,7 @@ function _renderToString(
 				while (isDirty(component) && count++ < 25) {
 					unsetDirty(component);
 
-					if (renderState.renderHook) renderState.renderHook(vnode);
+					if (hooks.renderHook) hooks.renderHook(vnode);
 
 					try {
 						rendered = type.call(component, props, cctx);
@@ -454,7 +450,7 @@ function _renderToString(
 
 			if (
 				isClassComponent &&
-				renderState.errorBoundaries &&
+				hooks.errorBoundaries &&
 				(type.getDerivedStateFromError || component.componentDidCatch)
 			) {
 				// When a component returns a Fragment node we flatten it in core, so we
@@ -475,7 +471,7 @@ function _renderToString(
 						vnode,
 						asyncMode,
 						false,
-						renderState
+						hooks
 					);
 				} catch (err) {
 					if (type.getDerivedStateFromError) {
@@ -487,7 +483,7 @@ function _renderToString(
 					}
 
 					if (isDirty(component)) {
-						rendered = renderClassComponent(vnode, context, renderState);
+						rendered = renderClassComponent(vnode, context, hooks);
 						component = vnode[COMPONENT];
 
 						if (component.getChildContext != null) {
@@ -509,15 +505,15 @@ function _renderToString(
 							vnode,
 							asyncMode,
 							renderer,
-							renderState
+							hooks
 						);
 					}
 
 					return EMPTY_STR;
 				} finally {
-					if (renderState.afterDiff) renderState.afterDiff(vnode);
+					if (hooks.afterDiff) hooks.afterDiff(vnode);
 
-					if (renderState.unmountHook) renderState.unmountHook(vnode);
+					if (hooks.unmountHook) hooks.unmountHook(vnode);
 				}
 			}
 		}
@@ -541,13 +537,13 @@ function _renderToString(
 				vnode,
 				asyncMode,
 				renderer,
-				renderState
+				hooks
 			);
 
-			if (renderState.afterDiff) renderState.afterDiff(vnode);
+			if (hooks.afterDiff) hooks.afterDiff(vnode);
 			// when we are dealing with suspense we can't do this...
 
-			if (renderState.unmountHook) renderState.unmountHook(vnode);
+			if (hooks.unmountHook) hooks.unmountHook(vnode);
 
 			if (vnode._suspended) {
 				return wrapWithSuspenseMarkers(str);
@@ -568,7 +564,7 @@ function _renderToString(
 									parent,
 									asyncMode,
 									renderer,
-									renderState
+									hooks
 								)
 							);
 						} catch (e) {
@@ -580,7 +576,7 @@ function _renderToString(
 
 				if (res !== undefined) return res;
 
-				if (renderState.catchError) renderState.catchError(error, vnode);
+				if (hooks.catchError) hooks.catchError(error, vnode);
 				return EMPTY_STR;
 			}
 
@@ -599,7 +595,7 @@ function _renderToString(
 							vnode,
 							asyncMode,
 							renderer,
-							renderState
+							hooks
 						)
 					);
 					return vnode._suspended ? wrapWithSuspenseMarkers(result) : result;
@@ -761,13 +757,13 @@ function _renderToString(
 			vnode,
 			asyncMode,
 			renderer,
-			renderState
+			hooks
 		);
 	}
 
-	if (renderState.afterDiff) renderState.afterDiff(vnode);
+	if (hooks.afterDiff) hooks.afterDiff(vnode);
 
-	if (renderState.unmountHook) renderState.unmountHook(vnode);
+	if (hooks.unmountHook) hooks.unmountHook(vnode);
 
 	// Emit self-closing tag for empty void elements:
 	if (!html && SELF_CLOSING.has(type)) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,42 @@ function wrapWithSuspenseMarkers(result) {
 	return BEGIN_SUSPENSE_DENOMINATOR + result + END_SUSPENSE_DENOMINATOR;
 }
 
-// Global state for the current render pass
-let beforeDiff, afterDiff, renderHook, ummountHook;
+/**
+ * Capture the Preact option hooks used by a render so suspended subtrees don't
+ * observe hooks installed by another render before they resume.
+ * @returns {RenderState}
+ */
+function createRenderState() {
+	return {
+		beforeDiff: options[DIFF],
+		afterDiff: options[DIFFED],
+		renderHook: options[RENDER],
+		unmountHook: options.unmount,
+		rootHook: options[ROOT],
+		commitHook: options[COMMIT],
+		catchError: options[CATCH_ERROR],
+		errorBoundaries: options.errorBoundaries
+	};
+}
+
+/**
+ * Effects must only be skipped while a synchronous portion of a render is
+ * running. Keeping this flag set while awaiting Suspense would leak it into
+ * concurrent work and allow overlapping renders to restore a stale value.
+ * @template T
+ * @param {() => T} render
+ * @returns {T}
+ */
+function withSkipEffects(render) {
+	const previousSkipEffects = options[SKIP_EFFECTS];
+	options[SKIP_EFFECTS] = true;
+
+	try {
+		return render();
+	} finally {
+		options[SKIP_EFFECTS] = previousSkipEffects;
+	}
+}
 
 /**
  * Render Preact JSX + Components to an HTML string.
@@ -65,34 +99,27 @@ let beforeDiff, afterDiff, renderHook, ummountHook;
  * @returns {string} serialized HTML
  */
 export function renderToString(vnode, context, _rendererState) {
-	// Performance optimization: `renderToString` is synchronous and we
-	// therefore don't execute any effects. To do that we pass an empty
-	// array to `options._commit` (`__c`). But we can go one step further
-	// and avoid a lot of dirty checks and allocations by setting
-	// `options._skipEffects` (`__s`) too.
-	const previousSkipEffects = options[SKIP_EFFECTS];
-	options[SKIP_EFFECTS] = true;
-
-	// store options hooks once before each synchronous render call
-	beforeDiff = options[DIFF];
-	afterDiff = options[DIFFED];
-	renderHook = options[RENDER];
-	ummountHook = options.unmount;
-
-	const parent = h(Fragment, null);
-	parent[CHILDREN] = [vnode];
-	if (options[ROOT]) options[ROOT](vnode, { [CHILDREN]: parent, nodeType: 1 });
+	const renderState = createRenderState();
 
 	try {
-		const rendered = _renderToString(
-			vnode,
-			context || EMPTY_OBJ,
-			false,
-			undefined,
-			parent,
-			false,
-			_rendererState
-		);
+		const rendered = withSkipEffects(() => {
+			const parent = h(Fragment, null);
+			parent[CHILDREN] = [vnode];
+			if (renderState.rootHook) {
+				renderState.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
+			}
+
+			return _renderToString(
+				vnode,
+				context || EMPTY_OBJ,
+				false,
+				undefined,
+				parent,
+				false,
+				_rendererState,
+				renderState
+			);
+		});
 
 		if (isArray(rendered)) {
 			return rendered.join(EMPTY_STR);
@@ -107,8 +134,9 @@ export function renderToString(vnode, context, _rendererState) {
 	} finally {
 		// options._commit, we don't schedule any effects in this library right now,
 		// so we can pass an empty queue to this hook.
-		if (options[COMMIT]) options[COMMIT](vnode, EMPTY_ARR);
-		options[SKIP_EFFECTS] = previousSkipEffects;
+		if (renderState.commitHook) {
+			withSkipEffects(() => renderState.commitHook(vnode, EMPTY_ARR));
+		}
 		EMPTY_ARR.length = 0;
 	}
 }
@@ -120,34 +148,27 @@ export function renderToString(vnode, context, _rendererState) {
  * @returns {string} serialized HTML
  */
 export async function renderToStringAsync(vnode, context) {
-	// Performance optimization: `renderToString` is synchronous and we
-	// therefore don't execute any effects. To do that we pass an empty
-	// array to `options._commit` (`__c`). But we can go one step further
-	// and avoid a lot of dirty checks and allocations by setting
-	// `options._skipEffects` (`__s`) too.
-	const previousSkipEffects = options[SKIP_EFFECTS];
-	options[SKIP_EFFECTS] = true;
-
-	// store options hooks once before each synchronous render call
-	beforeDiff = options[DIFF];
-	afterDiff = options[DIFFED];
-	renderHook = options[RENDER];
-	ummountHook = options.unmount;
-
-	const parent = h(Fragment, null);
-	parent[CHILDREN] = [vnode];
-	if (options[ROOT]) options[ROOT](vnode, { [CHILDREN]: parent, nodeType: 1 });
+	const renderState = createRenderState();
 
 	try {
-		const rendered = await _renderToString(
-			vnode,
-			context || EMPTY_OBJ,
-			false,
-			undefined,
-			parent,
-			true,
-			undefined
-		);
+		const rendered = await withSkipEffects(() => {
+			const parent = h(Fragment, null);
+			parent[CHILDREN] = [vnode];
+			if (renderState.rootHook) {
+				renderState.rootHook(vnode, { [CHILDREN]: parent, nodeType: 1 });
+			}
+
+			return _renderToString(
+				vnode,
+				context || EMPTY_OBJ,
+				false,
+				undefined,
+				parent,
+				true,
+				undefined,
+				renderState
+			);
+		});
 
 		if (isArray(rendered)) {
 			let count = 0;
@@ -170,8 +191,9 @@ export async function renderToStringAsync(vnode, context) {
 	} finally {
 		// options._commit, we don't schedule any effects in this library right now,
 		// so we can pass an empty queue to this hook.
-		if (options[COMMIT]) options[COMMIT](vnode, EMPTY_ARR);
-		options[SKIP_EFFECTS] = previousSkipEffects;
+		if (renderState.commitHook) {
+			withSkipEffects(() => renderState.commitHook(vnode, EMPTY_ARR));
+		}
 		EMPTY_ARR.length = 0;
 	}
 }
@@ -179,8 +201,9 @@ export async function renderToStringAsync(vnode, context) {
 /**
  * @param {VNode} vnode
  * @param {Record<string, unknown>} context
+ * @param {RenderState} renderState
  */
-function renderClassComponent(vnode, context) {
+function renderClassComponent(vnode, context, renderState) {
 	let type =
 		/** @type {import("preact").ComponentClass<typeof vnode.props>} */ (
 			vnode.type
@@ -227,7 +250,7 @@ function renderClassComponent(vnode, context) {
 		c.componentWillUpdate();
 	}
 
-	if (renderHook) renderHook(vnode);
+	if (renderState.renderHook) renderState.renderHook(vnode);
 
 	return c.render(c.props, c.state, context);
 }
@@ -240,7 +263,8 @@ function renderClassComponent(vnode, context) {
  * @param {any} selectValue
  * @param {VNode} parent
  * @param {boolean} asyncMode
- * @param {RendererState | undefined} [renderer]
+ * @param {RendererState | undefined | false} renderer
+ * @param {RenderState} renderState
  * @returns {string | Promise<string> | (string | Promise<string>)[]}
  */
 function _renderToString(
@@ -250,7 +274,8 @@ function _renderToString(
 	selectValue,
 	parent,
 	asyncMode,
-	renderer
+	renderer,
+	renderState
 ) {
 	// Ignore non-rendered VNodes/values
 	if (
@@ -286,7 +311,8 @@ function _renderToString(
 				selectValue,
 				parent,
 				asyncMode,
-				renderer
+				renderer,
+				renderState
 			);
 
 			if (typeof childRender == 'string') {
@@ -321,7 +347,7 @@ function _renderToString(
 	if (vnode.constructor !== undefined) return EMPTY_STR;
 
 	vnode[PARENT] = parent;
-	if (beforeDiff) beforeDiff(vnode);
+	if (renderState.beforeDiff) renderState.beforeDiff(vnode);
 
 	let type = vnode.type,
 		props = vnode.props;
@@ -357,7 +383,8 @@ function _renderToString(
 									selectValue,
 									vnode,
 									asyncMode,
-									renderer
+									renderer,
+									renderState
 								);
 						} else {
 							// Values are pre-escaped by the JSX transform
@@ -384,7 +411,11 @@ function _renderToString(
 			let isClassComponent =
 				type.prototype && typeof type.prototype.render == 'function';
 			if (isClassComponent) {
-				rendered = /**#__NOINLINE__**/ renderClassComponent(vnode, cctx);
+				rendered = /**#__NOINLINE__**/ renderClassComponent(
+					vnode,
+					cctx,
+					renderState
+				);
 				component = vnode[COMPONENT];
 			} else {
 				vnode[COMPONENT] = component = /**#__NOINLINE__**/ createComponent(
@@ -401,7 +432,7 @@ function _renderToString(
 				while (isDirty(component) && count++ < 25) {
 					unsetDirty(component);
 
-					if (renderHook) renderHook(vnode);
+					if (renderState.renderHook) renderState.renderHook(vnode);
 
 					try {
 						rendered = type.call(component, props, cctx);
@@ -423,7 +454,7 @@ function _renderToString(
 
 			if (
 				isClassComponent &&
-				options.errorBoundaries &&
+				renderState.errorBoundaries &&
 				(type.getDerivedStateFromError || component.componentDidCatch)
 			) {
 				// When a component returns a Fragment node we flatten it in core, so we
@@ -444,7 +475,7 @@ function _renderToString(
 						vnode,
 						asyncMode,
 						false,
-						renderer
+						renderState
 					);
 				} catch (err) {
 					if (type.getDerivedStateFromError) {
@@ -456,7 +487,7 @@ function _renderToString(
 					}
 
 					if (isDirty(component)) {
-						rendered = renderClassComponent(vnode, context);
+						rendered = renderClassComponent(vnode, context, renderState);
 						component = vnode[COMPONENT];
 
 						if (component.getChildContext != null) {
@@ -477,15 +508,16 @@ function _renderToString(
 							selectValue,
 							vnode,
 							asyncMode,
-							renderer
+							renderer,
+							renderState
 						);
 					}
 
 					return EMPTY_STR;
 				} finally {
-					if (afterDiff) afterDiff(vnode);
+					if (renderState.afterDiff) renderState.afterDiff(vnode);
 
-					if (ummountHook) ummountHook(vnode);
+					if (renderState.unmountHook) renderState.unmountHook(vnode);
 				}
 			}
 		}
@@ -508,13 +540,14 @@ function _renderToString(
 				selectValue,
 				vnode,
 				asyncMode,
-				renderer
+				renderer,
+				renderState
 			);
 
-			if (afterDiff) afterDiff(vnode);
+			if (renderState.afterDiff) renderState.afterDiff(vnode);
 			// when we are dealing with suspense we can't do this...
 
-			if (options.unmount) options.unmount(vnode);
+			if (renderState.unmountHook) renderState.unmountHook(vnode);
 
 			if (vnode._suspended) {
 				return wrapWithSuspenseMarkers(str);
@@ -526,14 +559,17 @@ function _renderToString(
 				const onError = (error) => {
 					return renderer.onError(error, vnode, (child, parent) => {
 						try {
-							return _renderToString(
-								child,
-								context,
-								isSvgMode,
-								selectValue,
-								parent,
-								asyncMode,
-								renderer
+							return withSkipEffects(() =>
+								_renderToString(
+									child,
+									context,
+									isSvgMode,
+									selectValue,
+									parent,
+									asyncMode,
+									renderer,
+									renderState
+								)
 							);
 						} catch (e) {
 							return onError(e);
@@ -544,8 +580,7 @@ function _renderToString(
 
 				if (res !== undefined) return res;
 
-				let errorHook = options[CATCH_ERROR];
-				if (errorHook) errorHook(error, vnode);
+				if (renderState.catchError) renderState.catchError(error, vnode);
 				return EMPTY_STR;
 			}
 
@@ -555,14 +590,17 @@ function _renderToString(
 
 			const renderNestedChildren = () => {
 				try {
-					const result = _renderToString(
-						rendered,
-						context,
-						isSvgMode,
-						selectValue,
-						vnode,
-						asyncMode,
-						renderer
+					const result = withSkipEffects(() =>
+						_renderToString(
+							rendered,
+							context,
+							isSvgMode,
+							selectValue,
+							vnode,
+							asyncMode,
+							renderer,
+							renderState
+						)
 					);
 					return vnode._suspended ? wrapWithSuspenseMarkers(result) : result;
 				} catch (e) {
@@ -722,13 +760,14 @@ function _renderToString(
 			selectValue,
 			vnode,
 			asyncMode,
-			renderer
+			renderer,
+			renderState
 		);
 	}
 
-	if (afterDiff) afterDiff(vnode);
+	if (renderState.afterDiff) renderState.afterDiff(vnode);
 
-	if (ummountHook) ummountHook(vnode);
+	if (renderState.unmountHook) renderState.unmountHook(vnode);
 
 	// Emit self-closing tag for empty void elements:
 	if (!html && SELF_CLOSING.has(type)) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -27,6 +27,17 @@ interface RendererState {
 	onError?: RendererErrorHandler;
 }
 
+interface RenderState {
+	beforeDiff?: (vnode: VNode) => void;
+	afterDiff?: (vnode: VNode) => void;
+	renderHook?: (vnode: VNode) => void;
+	unmountHook?: (vnode: VNode) => void;
+	rootHook?: (vnode: VNode, parentDom: any) => void;
+	commitHook?: (vnode: VNode, commitQueue: any[]) => void;
+	catchError?: (error: any, vnode: VNode) => void;
+	errorBoundaries?: boolean;
+}
+
 interface RenderToChunksOptions {
 	context?: any;
 	onError?: (error: any) => void;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -27,7 +27,7 @@ interface RendererState {
 	onError?: RendererErrorHandler;
 }
 
-interface RenderState {
+interface CapturedHooks {
 	beforeDiff?: (vnode: VNode) => void;
 	afterDiff?: (vnode: VNode) => void;
 	renderHook?: (vnode: VNode) => void;

--- a/test/compat/async.test.jsx
+++ b/test/compat/async.test.jsx
@@ -1,11 +1,114 @@
-import { renderToStringAsync } from '../../src/index.js';
-import { h, Fragment } from 'preact';
+import { renderToString, renderToStringAsync } from '../../src/index.js';
+import { h, Fragment, options } from 'preact';
 import { Suspense, useId, lazy, createContext } from 'preact/compat';
 import { expect, describe, it } from 'vitest';
 import { createSuspender } from '../utils.jsx';
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
 describe('Async renderToString', () => {
+	it('should isolate options hooks across suspended renders', async () => {
+		const original = {
+			beforeDiff: options.__b,
+			renderHook: options.__r,
+			afterDiff: options.diffed,
+			unmountHook: options.unmount,
+			commitHook: options.__c,
+			skipEffects: options.__s
+		};
+		const calls = [];
+		const record = (label, hook, vnode) => {
+			calls.push([label, hook, vnode.type]);
+		};
+		const install = (label) => {
+			options.__b = (vnode) => {
+				record(label, 'beforeDiff', vnode);
+				if (original.beforeDiff) original.beforeDiff(vnode);
+			};
+			options.__r = (vnode) => {
+				record(label, 'render', vnode);
+				if (original.renderHook) original.renderHook(vnode);
+			};
+			options.diffed = (vnode) => {
+				record(label, 'afterDiff', vnode);
+				if (original.afterDiff) original.afterDiff(vnode);
+			};
+			options.unmount = (vnode) => {
+				record(label, 'unmount', vnode);
+				if (original.unmountHook) original.unmountHook(vnode);
+			};
+			options.__c = (vnode, commitQueue) => {
+				record(label, 'commit', vnode);
+				if (original.commitHook) original.commitHook(vnode, commitQueue);
+			};
+		};
+
+		const { Suspender, suspended } = createSuspender();
+		let skipEffectsDuringResume;
+		function Child() {
+			skipEffectsDuringResume = options.__s;
+			return <span>first</span>;
+		}
+		function Parent() {
+			return (
+				<Suspense fallback={null}>
+					<Suspender>
+						<Child />
+					</Suspender>
+				</Suspense>
+			);
+		}
+
+		try {
+			options.__s = false;
+			install('first');
+			const pending = renderToStringAsync(<Parent />);
+
+			// Suspended renders must not leak the skip-effects flag globally.
+			expect(options.__s).to.equal(false);
+
+			install('second');
+			renderToString(<aside>second</aside>);
+			expect(options.__s).to.equal(false);
+
+			suspended.resolve();
+			expect(await pending).to.equal('<!--$s--><span>first</span><!--/$s-->');
+
+			expect(
+				calls.filter(
+					([label, hook, type]) =>
+						label === 'first' && hook === 'render' && type === Suspender
+				)
+			).to.have.length(2);
+			expect(
+				calls.filter(
+					([label, hook, type]) =>
+						label === 'second' && hook === 'render' && type === Suspender
+				)
+			).to.have.length(0);
+			expect(
+				calls.some(
+					([label, hook, type]) =>
+						label === 'first' && hook === 'commit' && type === Parent
+				)
+			).to.equal(true);
+			expect(
+				calls.some(
+					([label, hook, type]) =>
+						label === 'second' && hook === 'commit' && type === Parent
+				)
+			).to.equal(false);
+			expect(options.__s).to.equal(false);
+			expect(skipEffectsDuringResume).to.equal(true);
+		} finally {
+			options.__b = original.beforeDiff;
+			options.__r = original.renderHook;
+			options.diffed = original.afterDiff;
+			options.unmount = original.unmountHook;
+			options.__c = original.commitHook;
+			options.__s = original.skipEffects;
+		}
+	});
+
 	it('should render JSX after a suspense boundary', async () => {
 		const { Suspender, suspended } = createSuspender();
 


### PR DESCRIPTION
## Summary

- capture Preact option hooks in per-render state so Suspense resumptions keep using the hooks active when rendering started
- scope `options._skipEffects` to synchronous render work so suspended and overlapping renders do not leak or restore stale global state
- use the captured hooks consistently for root, commit, unmount, and error handling