### PR TITLE
feat: async nonce support

### DIFF
--- a/.changeset/olive-lamps-agree.md
+++ b/.changeset/olive-lamps-agree.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": minor
+---
+
+async rendering nonce support

--- a/.changeset/olive-lamps-agree.md
+++ b/.changeset/olive-lamps-agree.md
@@ -2,4 +2,6 @@
 "preact-render-to-string": minor
 ---
 
-async rendering nonce support
+Replaces the second `context` argument in our streaming functions with an `options` object, the `context` moves to the third position.
+
+Streaming is considered alpha so we're making this breaking change deliberately as part of a minor.

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -32,4 +32,5 @@ interface RenderToChunksOptions {
 	onError?: (error: any) => void;
 	onWrite: (str: string) => void;
 	abortSignal?: AbortSignal;
+	nonce?: string;
 }

--- a/src/lib/chunked.js
+++ b/src/lib/chunked.js
@@ -8,7 +8,7 @@ import { createInitScript, createSubtree } from './client.js';
  * @param {RenderToChunksOptions} options
  * @returns {Promise<void>}
  */
-export async function renderToChunks(vnode, { context, onWrite, abortSignal }) {
+export async function renderToChunks(vnode, { context, onWrite, abortSignal, nonce }) {
 	context = context || {};
 
 	/** @type {RendererState} */
@@ -38,7 +38,7 @@ export async function renderToChunks(vnode, { context, onWrite, abortSignal }) {
 		const prefix = hasHtmlTag ? '<!DOCTYPE html>' : '';
 		onWrite(prefix + initialWrite);
 		onWrite('<div hidden>');
-		onWrite(createInitScript(len));
+		onWrite(createInitScript(nonce));
 		// We should keep checking all promises
 		await forkPromises(renderer);
 		onWrite('</div>');

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -1,3 +1,5 @@
+import { encodeEntities } from "./util.js"
+
 /* eslint-disable no-var, key-spacing, object-curly-spacing, prefer-arrow-callback, semi, keyword-spacing */
 
 // function initPreactIslandElement() {
@@ -48,8 +50,12 @@
 // To modify the INIT_SCRIPT, uncomment the above code, modify it, and paste it into https://try.terser.org/.
 const INIT_SCRIPT = `class e extends HTMLElement{connectedCallback(){var e=this;if(!e.isConnected)return;let t=this.getAttribute("data-target");if(t){for(var r,a,i=document.createNodeIterator(document,128);i.nextNode();){let e=i.referenceNode;if(e.data=="$s:"+t?r=e:e.data=="/$s:"+t&&(a=e),r&&a)break}r&&a&&r.parentNode!==document&&requestAnimationFrame((()=>{for(var t=a.previousSibling;t!=r&&t&&t!=r;)a.parentNode.removeChild(t),t=a.previousSibling;for(i=r;e.firstChild;)r=e.firstChild,e.removeChild(r),i.after(r),i=r;e.parentNode.removeChild(e)}))}}}customElements.define("preact-island",e);`;
 
-export function createInitScript() {
-	return `<script>(function(){${INIT_SCRIPT}}())</script>`;
+/**
+ * @param {string} nonce
+ * @returns {string}
+ */
+export function createInitScript(nonce) {
+	return `<script${nonce ? ` nonce="${encodeEntities(nonce)}"` : ''}>(function(){${INIT_SCRIPT}}())</script>`;
 }
 
 /**

--- a/src/stream-node.d.ts
+++ b/src/stream-node.d.ts
@@ -2,6 +2,7 @@ import { VNode } from 'preact';
 import { WritableStream } from 'node:stream';
 
 interface RenderToPipeableStreamOptions {
+	nonce?: string;
 	onShellReady?: () => void;
 	onAllReady?: () => void;
 	onError?: (error: any) => void;

--- a/src/stream-node.js
+++ b/src/stream-node.js
@@ -29,6 +29,7 @@ export function renderToPipeableStream(vnode, options, context) {
 	renderToChunks(vnode, {
 		context,
 		abortSignal: controller.signal,
+		nonce: options.nonce,
 		onError: (error) => {
 			if (options.onError) {
 				options.onError(error);

--- a/src/stream.d.ts
+++ b/src/stream.d.ts
@@ -4,7 +4,12 @@ interface RenderStream extends ReadableStream<Uint8Array> {
 	allReady: Promise<void>;
 }
 
+interface RenderToReadableStreamOptions {
+	nonce?: string;
+}
+
 export function renderToReadableStream<P = {}>(
 	vnode: VNode<P>,
+	options?: RenderToReadableStreamOptions,
 	context?: any
 ): RenderStream;

--- a/src/stream.js
+++ b/src/stream.js
@@ -5,10 +5,11 @@ import { renderToChunks } from './lib/chunked.js';
 
 /**
  * @param {import('preact').VNode} vnode
+ * @param {any} [options]
  * @param {any} [context]
  * @returns {RenderStream}
  */
-export function renderToReadableStream(vnode, context) {
+export function renderToReadableStream(vnode, options, context) {
 	/** @type {Deferred<void>} */
 	const allReady = new Deferred();
 	const encoder = new TextEncoder('utf-8');
@@ -18,6 +19,7 @@ export function renderToReadableStream(vnode, context) {
 		start(controller) {
 			renderToChunks(vnode, {
 				context,
+				nonce: options?.nonce,
 				onError: (error) => {
 					allReady.reject(error);
 					controller.abort(error);

--- a/test/compat/render-chunked.test.jsx
+++ b/test/compat/render-chunked.test.jsx
@@ -64,7 +64,7 @@ describe('renderToChunks', () => {
 		expect(result).to.deep.equal([
 			'<div><!--$s:10-->loading...<!--/$s:10--></div>',
 			'<div hidden>',
-			createInitScript(1),
+			createInitScript(),
 			'</div>'
 		]);
 	});
@@ -111,7 +111,7 @@ describe('renderToChunks', () => {
 		expect(result).to.deep.equal([
 			'<div><!--$s:16-->loading...<!--/$s:16--></div>',
 			'<div hidden>',
-			createInitScript(1),
+			createInitScript(),
 			createSubtree('16', '<p>it works</p>'),
 			'</div>'
 		]);
@@ -144,7 +144,7 @@ describe('renderToChunks', () => {
 		expect(result).to.deep.equal([
 			'<div><p>id: P0-0</p><!--$s:24-->loading...<!--/$s:24--></div>',
 			'<div hidden>',
-			createInitScript(1),
+			createInitScript(),
 			createSubtree('24', '<p>id: P0-1</p>'),
 			'</div>'
 		]);
@@ -184,7 +184,7 @@ describe('renderToChunks', () => {
 		expect(result).toEqual([
 			'<div><p>id: P0-0</p><!--$s:33-->loading...<!--/$s:33--><!--$s:36-->loading...<!--/$s:36--></div>',
 			'<div hidden>',
-			createInitScript(1),
+			createInitScript(),
 			createSubtree('33', '<p>id: P0-1</p>'),
 			createSubtree('36', '<p>id: P0-2</p>'),
 			'</div>'
@@ -307,9 +307,50 @@ describe('renderToChunks', () => {
 		expect(result).to.deep.equal([
 			'<div><!--$s:70-->loading part 1...<!--/$s:70--></div>',
 			'<div hidden>',
-			createInitScript(1),
+			createInitScript(),
 			createSubtree('70', '<p>it works</p><p>it works</p>'),
 			'</div>'
 		]);
+	});
+
+	it('should include the nonce attribute on the init script when a nonce is provided', async () => {
+		const { Suspender, suspended } = createSuspender();
+
+		const result = [];
+		const promise = renderToChunks(
+			<div>
+				<Suspense fallback="loading...">
+					<Suspender />
+				</Suspense>
+			</div>,
+			{ onWrite: (s) => result.push(s), nonce: 'r4nd0m-nonce' }
+		);
+		suspended.resolve();
+		await promise;
+
+		const fullHtml = result.join('');
+		expect(fullHtml).to.contain('<script nonce="r4nd0m-nonce">');
+
+		// The init script should be the only script emitted
+		expect(result[2]).to.equal(createInitScript('r4nd0m-nonce'));
+	});
+});
+
+describe('createInitScript', () => {
+	it('should not include a nonce attribute by default', () => {
+		const script = createInitScript();
+		expect(script.startsWith('<script>')).to.be.true;
+		expect(script).to.not.contain('nonce=');
+	});
+
+	it('should include a nonce attribute when a nonce is provided', () => {
+		const script = createInitScript('r4nd0m-nonce');
+		expect(script.startsWith('<script nonce="r4nd0m-nonce">')).to.be.true;
+	});
+
+	it('should encode HTML entities in the nonce', () => {
+		const script = createInitScript('a"b&c<d');
+		expect(script.startsWith('<script nonce="a&quot;b&amp;c&lt;d">')).to.be
+			.true;
 	});
 });

--- a/test/compat/stream-node.test.jsx
+++ b/test/compat/stream-node.test.jsx
@@ -88,4 +88,29 @@ describe('renderToPipeableStream', () => {
 
 		expect(error).to.be.undefined;
 	});
+
+	it('should include the nonce attribute on the init script when a nonce is provided', async () => {
+		const { Suspender, suspended } = createSuspender();
+
+		const sink = createSink();
+		const { pipe } = renderToPipeableStream(
+			<div>
+				<Suspense fallback="loading...">
+					<Suspender />
+				</Suspense>
+			</div>,
+			{
+				nonce: 'r4nd0m-nonce',
+				onShellReady: () => {
+					pipe(sink.stream);
+				}
+			}
+		);
+		suspended.resolve();
+
+		const result = await sink.promise;
+
+		expect(result.join('')).to.contain('<script nonce="r4nd0m-nonce">');
+		expect(result.join('')).to.not.contain('<script>');
+	});
 });

--- a/test/compat/stream.test.jsx
+++ b/test/compat/stream.test.jsx
@@ -74,6 +74,7 @@ describe('renderToReadableStream', () => {
 					<Suspender />
 				</Suspense>
 			</div>,
+			undefined,
 			{ onWrite: (s) => result.push(s) }
 		);
 		const sink = createSink(stream);
@@ -88,5 +89,25 @@ describe('renderToReadableStream', () => {
 			createSubtree('5', '<p>it works</p>'),
 			'</div>'
 		]);
+	});
+
+	it('should include the nonce attribute on the init script when a nonce is provided', async () => {
+		const { Suspender, suspended } = createSuspender();
+
+		const stream = await renderToReadableStream(
+			<div>
+				<Suspense fallback="loading...">
+					<Suspender />
+				</Suspense>
+			</div>,
+			{ nonce: 'r4nd0m-nonce' }
+		);
+		const sink = createSink(stream);
+		suspended.resolve();
+
+		const result = await sink.promise;
+
+		expect(result.join('')).to.contain('<script nonce="r4nd0m-nonce">');
+		expect(result.join('')).to.not.contain('<script>');
 	});
 });


### PR DESCRIPTION
Can't use a CSP headers with async rendering at the moment without allowing `unsafe-inline`.