### PR TITLE
Fix stream-node writable type

### DIFF
--- a/.changeset/fuzzy-streams-write.md
+++ b/.changeset/fuzzy-streams-write.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+Use Node's `Writable` type for `renderToPipeableStream` destinations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@changesets/changelog-github": "^1.0.0",
 				"@changesets/cli": "^3.0.0",
 				"@preact/signals-core": "^1.11.0",
+				"@types/node": "^20.19.43",
 				"baseline-rts": "npm:preact-render-to-string@latest",
 				"benchmarkjs-pretty": "^2.0.1",
 				"check-export-map": "^1.3.1",
@@ -3159,13 +3160,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.0.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.6.tgz",
-			"integrity": "sha512-ZOyn+gOs749xU7ovp+Ibj0g1o3dFRqsfPnT22C2t5JzcRvgsEDpGawPbCISGKLudJk9Y0wiu9sYd6kUh0pc9TA==",
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.8.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/parse-json": {
@@ -12412,9 +12413,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
 		"@changesets/changelog-github": "^1.0.0",
 		"@changesets/cli": "^3.0.0",
 		"@preact/signals-core": "^1.11.0",
+		"@types/node": "^20.19.43",
 		"baseline-rts": "npm:preact-render-to-string@latest",
 		"benchmarkjs-pretty": "^2.0.1",
 		"check-export-map": "^1.3.1",

--- a/src/stream-node.d.ts
+++ b/src/stream-node.d.ts
@@ -1,5 +1,5 @@
 import { VNode } from 'preact';
-import { WritableStream } from 'node:stream';
+import { Writable } from 'node:stream';
 
 interface RenderToPipeableStreamOptions {
 	nonce?: string;
@@ -10,7 +10,7 @@ interface RenderToPipeableStreamOptions {
 
 interface PipeableStream {
 	abort: (reason?: unknown) => void;
-	pipe: (writable: WritableStream) => void;
+	pipe: (writable: Writable) => void;
 }
 
 export function renderToPipeableStream<P = {}>(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,15 +10,20 @@
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
-            "../"
+            "../",
+            "./node_modules/@types"
         ],
         "jsx": "react",
         "jsxFactory": "h",
-        "types": [],
+        "types": [
+            "node"
+        ],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "src/index.d.ts"
+        "src/index.d.ts",
+        "src/stream.d.ts",
+        "src/stream-node.d.ts"
     ]
 }


### PR DESCRIPTION
## Summary

- replace the nonexistent `node:stream` `WritableStream` export with `Writable`
- type-check the stream entry declarations so invalid type imports are caught before publishing
- add an explicit compatible `@types/node` development dependency and a patch changeset

Confirmed with `npm test`.