### PR TITLE
Fix streaming empty Suspense boundaries

### DIFF
--- a/.changeset/tiny-pandas-stream.md
+++ b/.changeset/tiny-pandas-stream.md
@@ -1,0 +1,5 @@
+---
+"preact-render-to-string": patch
+---
+
+Replace streamed Suspense fallbacks when the resolved content is empty.

--- a/src/lib/chunked.js
+++ b/src/lib/chunked.js
@@ -8,7 +8,10 @@ import { createInitScript, createSubtree } from './client.js';
  * @param {RenderToChunksOptions} options
  * @returns {Promise<void>}
  */
-export async function renderToChunks(vnode, { context, onWrite, abortSignal, nonce }) {
+export async function renderToChunks(
+	vnode,
+	{ context, onWrite, abortSignal, nonce }
+) {
 	context = context || {};
 
 	/** @type {RendererState} */
@@ -97,8 +100,12 @@ function handleError(error, vnode, renderChild) {
 	const promise = error.then(
 		() => {
 			if (abortSignal && abortSignal.aborted) return;
+			const suspendedCount = this.suspended.length;
 			const child = renderChild(vnode.props.children, vnode);
-			if (child) this.onWrite(createSubtree(id, child));
+			const suspendedAgain = this.suspended
+				.slice(suspendedCount)
+				.some((suspension) => suspension.id === id);
+			if (!suspendedAgain) this.onWrite(createSubtree(id, child));
 		},
 		// TODO: Abort and send hydration code snippet to client
 		// to attempt to recover during hydration

--- a/test/compat/render-chunked.test.jsx
+++ b/test/compat/render-chunked.test.jsx
@@ -334,6 +334,68 @@ describe('renderToChunks', () => {
 		// The init script should be the only script emitted
 		expect(result[2]).to.equal(createInitScript('r4nd0m-nonce'));
 	});
+
+	it.each([
+		['null', null],
+		['false', false],
+		['an empty string', ''],
+		['an empty array', []]
+	])(
+		'should replace the fallback when suspended content resolves to %s',
+		async (_, children) => {
+			const { Suspender, suspended } = createSuspender();
+			const result = [];
+			const promise = renderToChunks(
+				<Suspense fallback="loading...">
+					<Suspender>{children}</Suspender>
+				</Suspense>,
+				{ onWrite: (chunk) => result.push(chunk) }
+			);
+
+			suspended.resolve();
+			await promise;
+
+			const id = result[0].match(/\$s:(\d+)/)[1];
+			expect(result).toEqual([
+				`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
+				'<div hidden>',
+				createInitScript(),
+				createSubtree(id, ''),
+				'</div>'
+			]);
+		}
+	);
+
+	it('should wait for every suspension in a boundary before patching it', async () => {
+		const first = createSuspender();
+		const second = createSuspender();
+		const result = [];
+		const promise = renderToChunks(
+			<Suspense fallback="loading...">
+				<first.Suspender>
+					<p>first</p>
+				</first.Suspender>
+				<second.Suspender>
+					<p>second</p>
+				</second.Suspender>
+			</Suspense>,
+			{ onWrite: (chunk) => result.push(chunk) }
+		);
+
+		first.suspended.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(
+			result.filter((chunk) => chunk.startsWith('<preact-island'))
+		).toEqual([]);
+
+		second.suspended.resolve();
+		await promise;
+		const patches = result.filter((chunk) =>
+			chunk.startsWith('<preact-island')
+		);
+		expect(patches).toHaveLength(1);
+		expect(patches[0]).toContain('<p>first</p><p>second</p>');
+	});
 });
 
 describe('createInitScript', () => {

--- a/test/compat/stream-node.test.jsx
+++ b/test/compat/stream-node.test.jsx
@@ -113,4 +113,28 @@ describe('renderToPipeableStream', () => {
 		expect(result.join('')).to.contain('<script nonce="r4nd0m-nonce">');
 		expect(result.join('')).to.not.contain('<script>');
 	});
+
+	it('should replace the fallback when suspended content resolves empty', async () => {
+		const { Suspender, suspended } = createSuspender();
+		const sink = createSink();
+		const { pipe } = renderToPipeableStream(
+			<Suspense fallback="loading...">
+				<Suspender>{null}</Suspender>
+			</Suspense>,
+			{
+				onShellReady: () => pipe(sink.stream)
+			}
+		);
+		suspended.resolve();
+
+		const result = await sink.promise;
+		const id = result[0].match(/\$s:(\d+)/)[1];
+		expect(result).toEqual([
+			`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
+			'<div hidden>',
+			createInitScript(),
+			createSubtree(id, ''),
+			'</div>'
+		]);
+	});
 });

--- a/test/compat/stream.test.jsx
+++ b/test/compat/stream.test.jsx
@@ -110,4 +110,25 @@ describe('renderToReadableStream', () => {
 		expect(result.join('')).to.contain('<script nonce="r4nd0m-nonce">');
 		expect(result.join('')).to.not.contain('<script>');
 	});
+
+	it('should replace the fallback when suspended content resolves empty', async () => {
+		const { Suspender, suspended } = createSuspender();
+		const stream = renderToReadableStream(
+			<Suspense fallback="loading...">
+				<Suspender>{null}</Suspender>
+			</Suspense>
+		);
+		const sink = createSink(stream);
+		suspended.resolve();
+
+		const result = await sink.promise;
+		const id = result[0].match(/\$s:(\d+)/)[1];
+		expect(result).toEqual([
+			`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
+			'<div hidden>',
+			createInitScript(),
+			createSubtree(id, ''),
+			'</div>'
+		]);
+	});
 });


### PR DESCRIPTION
## Summary

- emit a subtree patch when a resolved Suspense boundary serializes to empty content
- avoid emitting an empty or partial patch when the same boundary suspends again during a retry
- cover null, false, empty string, and empty array results plus Web Stream and Node Stream adapter parity
- add a patch changeset