### PR TITLE
feat(dpu): DPU out of order streaming replacement based html end stamp

### DIFF
--- a/.changeset/swift-owls-stream.md
+++ b/.changeset/swift-owls-stream.md
@@ -1,0 +1,7 @@
+---
+"preact-render-to-string": minor
+---
+
+Stream deferred content using DPU `<template for>` patches and a MutationObserver client script instead of `<preact-island>` custom elements.
+
+Fallbacks are wrapped with processing-instruction markers, and SVG/MathML subtrees are re-parsed so they display correctly after replacement. Late `$p:` patches skip client-owned DOM so hydration is not overwritten. Streaming is still alpha, so this wire-format change is a minor.

--- a/src/lib/chunked.js
+++ b/src/lib/chunked.js
@@ -31,7 +31,7 @@ export async function renderToChunks(
 	const len = renderer.suspended.length;
 	if (len > 0) {
 		// When rendering a full HTML document, the shell ends with </body></html>.
-		// Inserting the deferred <div hidden> wrapper after </html> is invalid HTML
+		// Inserting deferred <template for> patches after </html> is invalid HTML
 		// and causes browsers to reject the content. Instead, we inject the deferred
 		// content before the closing tags, then emit them last.
 		const docSuffixIndex = getDocumentClosingTagsIndex(shell);
@@ -40,11 +40,9 @@ export async function renderToChunks(
 			docSuffixIndex !== -1 ? shell.slice(0, docSuffixIndex) : shell;
 		const prefix = hasHtmlTag ? '<!DOCTYPE html>' : '';
 		onWrite(prefix + initialWrite);
-		onWrite('<div hidden>');
 		onWrite(createInitScript(nonce));
 		// We should keep checking all promises
 		await forkPromises(renderer);
-		onWrite('</div>');
 		if (docSuffixIndex !== -1) onWrite(shell.slice(docSuffixIndex));
 	} else {
 		onWrite(shell);
@@ -120,5 +118,7 @@ function handleError(error, vnode, renderChild) {
 
 	const fallback = renderChild(vnode.props.fallback);
 
-	return found ? '' : `<!--$s:${id}-->${fallback}<!--/$s:${id}-->`;
+	return found
+		? ''
+		: `<!--$s:${id}--><?start name="${id}">${fallback}<?end><!--/$s:${id}-->`;
 }

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -2,92 +2,87 @@ import { encodeEntities } from './util.js';
 
 /* eslint-disable no-var, key-spacing, object-curly-spacing, prefer-arrow-callback, semi, keyword-spacing */
 
-// function initPreactIslandElement() {
-// 	class PreactIslandElement extends HTMLElement {
-// 		connectedCallback() {
-// 			var d = this;
-// 			if (!d.isConnected) return;
-
-// 			let i = this.getAttribute('data-target');
-// 			if (!i) return;
-
-// 			var s,
-// 				e,
-// 				c = document.createNodeIterator(document, 128);
-// 			while (c.nextNode()) {
-// 				let n = c.referenceNode;
-
-// 				if (n.data == '$s:' + i) s = n;
-// 				else if (n.data == '/$s:' + i) e = n;
-// 				if (s && e) break;
-// 			}
-// 			if (s && e && s.parentNode !== document) {
-// 				requestAnimationFrame(() => {
-// 					// Hydration may finish after connectedCallback queues this frame.
-// 					if (!d.isConnected || !s.isConnected || !e.isConnected || s.parentNode !== e.parentNode) {
-// 						d.remove();
-// 						return;
+// ((d) => {
+// 	new MutationObserver((mutations, observer) => {
+// 		for (let mutation of mutations) {
+// 			for (let node of mutation.addedNodes) {
+// 				// find all complete stamps in the DOM
+// 				if (node.nodeType == 8 && !node.data.indexOf("$p:")) {
+// 					let id = node.data.slice(3), // id of the template to replace
+// 					start, // start of the comment
+// 					end, // end of the comment
+// 					temp, // temp variable for the current node
+// 					iter = d.createTreeWalker(d, 128), // tree walker to find the start and end of the comments
+// 					hole = "$s:" + id, // start name for the comment to replace
+// 					next, // temp variable for the next item
+// 					nodes = [],
+// 					root,
+// 					owned = new Set(),
+// 					keep;
+// 					// find the start and end of the comments by traversing the tree
+// 					for (; (!start || !end) && (temp = iter.nextNode()); ) {
+//                       	if(temp.data == hole) start = temp;
+//                       	else if(temp.data == "/" + hole) end = temp;
 // 					}
-// 					var nodes = [], p = s.nextSibling, root = s.parentNode;
-// 					while (p && p !== e) {
-// 						nodes.push(p);
-// 						p = p.nextSibling;
-// 					}
-// 					if (!p) { d.remove(); return; }
-// 					// DOM already referenced by a rendered host/text VNode belongs to
-// 					// the client. A suspended component's fallback pointer does not.
-// 					while (root && !root.__k) root = root.parentNode;
-// 					var owned = new Set();
-// 					function visit(vnode) {
-// 						if (vnode) {
-// 							if (typeof vnode.type !== 'function' && vnode.__e && vnode.__e.parentNode === s.parentNode) owned.add(vnode.__e);
-// 							if (vnode.__k) vnode.__k.forEach(visit);
+// 					temp = d.querySelector('template[for="' + id + '"]');
+// 					// if the start and end are found continue
+// 					if (start && end && start.parentNode !== d && start.isConnected && end.isConnected && start.parentNode === end.parentNode) {
+// 						root = start.parentNode;
+// 						next = start.nextSibling;
+// 						while (next && next !== end) {
+// 							nodes.push(next);
+// 							next = next.nextSibling;
+// 						}
+// 						if (next) {
+// 							// DOM already referenced by a rendered host/text VNode belongs to
+// 							// the client. A suspended component's fallback pointer does not.
+// 							while (root && !root.__k) root = root.parentNode;
+// 							function visit(vnode) {
+// 								if (vnode) {
+// 									if (typeof vnode.type !== 'function' && vnode.__e && vnode.__e.parentNode === start.parentNode) owned.add(vnode.__e);
+// 									if (vnode.__k) vnode.__k.forEach(visit);
+// 								}
+// 							}
+// 							if (root) visit(root.__k);
+// 							keep = nodes.some(n => owned.has(n));
+// 							if (keep) {
+// 								let depth = 0;
+// 								nodes.forEach(n => {
+// 									if (n.nodeType === 8 && n.data.startsWith('$s')) depth++;
+// 									else if (n.nodeType === 8 && n.data.startsWith('/$s')) depth--;
+// 									else if (!depth && !owned.has(n)) n.remove();
+// 								});
+// 							} else if (temp) {
+// 								// Template is still in the document: native DPU did not apply it.
+// 								// Replace the fallback between the markers with the streamed content.
+// 								for (; (next = start.nextSibling) && next != end; ) {
+// 									next.remove();
+// 								}
+// 								start.after(temp.content);
+// 							}
 // 						}
 // 					}
-// 					if (root) visit(root.__k);
-// 					if (nodes.some(node => owned.has(node))) {
-// 						var depth = 0;
-// 						nodes.forEach(node => {
-// 							if (node.nodeType === 8 && node.data.startsWith('$s')) depth++;
-// 							else if (node.nodeType === 8 && node.data.startsWith('/$s')) depth--;
-// 							else if (!depth && !owned.has(node)) node.remove();
-// 						});
-// 						d.remove();
-// 						return;
-// 					}
-// 					p = e.previousSibling;
-// 					while (p != s) {
-// 						if (!p || p == s) break;
-// 						e.parentNode.removeChild(p);
-// 						p = e.previousSibling;
-// 					}
-
-// 					c = s;
-// 					while (d.firstChild) {
-// 						s = d.firstChild;
-// 						d.removeChild(s);
-// 						c.after(s);
-// 						c = s;
-// 					}
-
-// 					d.parentNode.removeChild(d);
-// 				});
-// 			} else d.remove();
+// 					if (temp) temp.remove();
+// 					node.remove();
+// 					// Reparse svg/math so HTML-namespace children (from template/DPU) get the right NS.
+// 					// closest() matches the element itself when the hole's parent is <svg>/<math>.
+// 					if (next && !keep) (temp = start.parentElement) && (temp = temp.closest("svg,math")) && (temp.innerHTML += "");
+// 				}
+// 			}
 // 		}
-// 	}
-
-// 	customElements.define('preact-island', PreactIslandElement);
-// }
+// 		d.readyState[0] != "l" && observer.disconnect();
+// 	}).observe(d, { childList: 1, subtree: 1 });
+// })(document);
 
 // To modify the INIT_SCRIPT, uncomment the above code, modify it, and paste it into https://try.terser.org/.
-const INIT_SCRIPT = `class e extends HTMLElement{connectedCallback(){var e=this;if(!e.isConnected)return;let t=this.getAttribute("data-target");if(t){for(var r,o,n=document.createNodeIterator(document,128);n.nextNode();){let e=n.referenceNode;if(e.data=="$s:"+t?r=e:e.data=="/$s:"+t&&(o=e),r&&o)break}r&&o&&r.parentNode!==document?requestAnimationFrame(()=>{if(e.isConnected&&r.isConnected&&o.isConnected&&r.parentNode===o.parentNode){for(var t=[],a=r.nextSibling,i=r.parentNode;a&&a!==o;)t.push(a),a=a.nextSibling;if(a){for(;i&&!i.__k;)i=i.parentNode;var d=new Set;if(i&&function e(t){t&&("function"!=typeof t.type&&t.__e&&t.__e.parentNode===r.parentNode&&d.add(t.__e),t.__k&&t.__k.forEach(e))}(i.__k),t.some(e=>d.has(e))){var s=0;return t.forEach(e=>{8===e.nodeType&&e.data.startsWith("$s")?s++:8===e.nodeType&&e.data.startsWith("/$s")?s--:s||d.has(e)||e.remove()}),void e.remove()}for(a=o.previousSibling;a!=r&&a&&a!=r;)o.parentNode.removeChild(a),a=o.previousSibling;for(n=r;e.firstChild;)r=e.firstChild,e.removeChild(r),n.after(r),n=r;e.parentNode.removeChild(e)}else e.remove()}else e.remove()}):e.remove()}}}customElements.define("preact-island",e);`;
+const INIT_SCRIPT = `(e=>{new MutationObserver((t,o)=>{for(let a of t)for(let r of a.addedNodes)if(8==r.nodeType&&!r.data.indexOf("$p:")){let d,i,s,f,l,p,c=r.data.slice(3),_=e.createTreeWalker(e,128),h="$s:"+c,m=[],N=new Set;for(;(!d||!i)&&(s=_.nextNode());)s.data==h?d=s:s.data=="/"+h&&(i=s);if(s=e.querySelector('template[for="'+c+'"]'),d&&i&&d.parentNode!==e&&d.isConnected&&i.isConnected&&d.parentNode===i.parentNode){for(l=d.parentNode,f=d.nextSibling;f&&f!==i;)m.push(f),f=f.nextSibling;if(f){for(;l&&!l.__k;)l=l.parentNode;function n(e){e&&("function"!=typeof e.type&&e.__e&&e.__e.parentNode===d.parentNode&&N.add(e.__e),e.__k&&e.__k.forEach(n))}if(l&&n(l.__k),p=m.some(e=>N.has(e)),p){let u=0;m.forEach(e=>{8===e.nodeType&&e.data.startsWith("$s")?u++:8===e.nodeType&&e.data.startsWith("/$s")?u--:u||N.has(e)||e.remove()})}else if(s){for(;(f=d.nextSibling)&&f!=i;)f.remove();d.after(s.content)}}}s&&s.remove(),r.remove(),f&&!p&&(s=d.parentElement)&&(s=s.closest("svg,math"))&&(s.innerHTML+="")}"l"!=e.readyState[0]&&o.disconnect()}).observe(e,{childList:1,subtree:1})})(document);`;
 
 /**
  * @param {string} nonce
  * @returns {string}
  */
 export function createInitScript(nonce) {
-	return `<script${nonce ? ` nonce="${encodeEntities(nonce)}"` : ''}>(function(){${INIT_SCRIPT}}())</script>`;
+	return `<script${nonce ? ` nonce="${encodeEntities(nonce)}"` : ''}>!function(){${INIT_SCRIPT}}();</script>`;
 }
 
 /**
@@ -96,5 +91,5 @@ export function createInitScript(nonce) {
  * @returns {string}
  */
 export function createSubtree(id, content) {
-	return `<preact-island hidden data-target="${id}">${content}</preact-island>`;
+	return `<template for="${id}">${content}</template><!--$p:${id}-->`;
 }

--- a/test/client.test.jsx
+++ b/test/client.test.jsx
@@ -1,79 +1,598 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { expect, describe, it, afterEach } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { h, render } from 'preact';
-import { createInitScript, createSubtree } from '../src/lib/client';
+import { createInitScript, createSubtree } from '../src/lib/client.js';
 
-let dom;
-const previousDocument = globalThis.document;
-afterEach(() => {
-	dom.window.close();
-	globalThis.document = previousDocument;
+/**
+ * @param {string} [bodyHtml]
+ */
+function createDom(bodyHtml = '') {
+	const dom = new JSDOM(
+		`<!DOCTYPE html><html><body>${bodyHtml}</body></html>`,
+		{
+			runScripts: 'dangerously',
+			url: 'http://localhost/'
+		}
+	);
+	return { dom, window: dom.window, document: dom.window.document };
+}
+
+/**
+ * Script body from a `<script>` / `<script nonce="...">` tag.
+ * @param {string} html
+ */
+function getScriptText(html) {
+	const match = /<script[^>]*>([\s\S]*)<\/script>/.exec(html);
+	expect(match).not.toBeNull();
+	return match[1];
+}
+
+/**
+ * Run the inline init script in a given window, the way a classic script tag would.
+ * @param {Window} window
+ */
+function runInitScript(window) {
+	window.eval(getScriptText(createInitScript()));
+}
+
+/**
+ * Flush MutationObserver callbacks scheduled by jsdom.
+ */
+function flushMutations() {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * @param {Document} document
+ * @param {'loading' | 'interactive' | 'complete'} state
+ */
+function setReadyState(document, state) {
+	Object.defineProperty(document, 'readyState', {
+		configurable: true,
+		get: () => state
+	});
+}
+
+/**
+ * @param {Document} document
+ * @param {string} id
+ * @param {string} html
+ */
+function appendTemplate(document, id, html) {
+	const template = document.createElement('template');
+	template.setAttribute('for', id);
+	if (html) template.innerHTML = html;
+	document.body.appendChild(template);
+	return template;
+}
+
+/**
+ * Signal that a streamed <template for> is complete by appending its $p: comment.
+ * @param {HTMLTemplateElement} template
+ * @param {string} id
+ */
+function appendPatchComment(template, id) {
+	template.after(template.ownerDocument.createComment('$p:' + id));
+}
+
+/**
+ * Append several HTML snippets as siblings in a single mutation.
+ * @param {Document} document
+ * @param {...string} htmlSnippets
+ */
+function appendTogether(document, ...htmlSnippets) {
+	const wrap = document.createElement('div');
+	wrap.innerHTML = htmlSnippets.join('');
+	const frag = document.createDocumentFragment();
+	while (wrap.firstChild) frag.appendChild(wrap.firstChild);
+	document.body.appendChild(frag);
+}
+
+describe('createSubtree', () => {
+	it('should wrap content in a template with a for attribute', () => {
+		expect(createSubtree('5', '<p>it works</p>')).toBe(
+			'<template for="5"><p>it works</p></template><!--$p:5-->'
+		);
+	});
 });
 
-function setup(
-	html = '<div id="root"><!--$s:1--><i>loading</i><!--/$s:1--></div>'
-) {
-	dom = new JSDOM(html, {
-		runScripts: 'dangerously',
-		url: 'http://localhost/'
+describe('createInitScript', () => {
+	it('should emit a script that sets up MutationObserver', () => {
+		const html = createInitScript();
+		expect(html.startsWith('<script>')).toBe(true);
+		expect(html.endsWith('</script>')).toBe(true);
+
+		const body = getScriptText(html);
+		expect(body).toContain('MutationObserver');
+		expect(body).toContain('$p:');
+		expect(body).toContain('$s:');
+		expect(body).toContain('disconnect');
+		expect(body).toContain('parentElement');
+		expect(body).toContain('closest("svg,math")');
+		expect(body).toContain('.content');
+		expect(() => new Function(body)).not.toThrow();
 	});
-	const { window } = dom;
-	globalThis.document = window.document;
-	const frames = [];
-	window.requestAnimationFrame = (callback) => frames.push(callback);
-	const script = createInitScript();
-	window.eval(script.slice('<script>'.length, -'</script>'.length));
-	return {
-		document: window.document,
-		root: window.document.querySelector('#root'),
-		flush: () => frames.splice(0).forEach((callback) => callback())
-	};
-}
+});
 
-function appendIsland(document, content = '<button>server</button>') {
-	document.body.insertAdjacentHTML('beforeend', createSubtree('1', content));
-}
+describe('inline init script', () => {
+	it('should replace fallback content when a $p: subtree arrives', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading...<!--/$s:1--></div>'
+		);
 
-function renderClient(root, children) {
-	root.replaceChildren();
-	render(children, root);
-	// Keep the stream anchors, as resumed hydration does in Preact 11.
-	root.prepend(document.createComment('$s:1'));
-	root.append(document.createComment('/$s:1'));
-}
+		runInitScript(window);
+		appendTogether(document, createSubtree('1', '<p>resolved</p>'));
+		await flushMutations();
+
+		expect(document.body.innerHTML).toBe(
+			'<div><!--$s:1--><p>resolved</p><!--/$s:1--></div>'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should strip processing-instruction fallback wrappers used by streaming', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:5--><?start name="5">loading...<?end><!--/$s:5--></div>'
+		);
+
+		runInitScript(window);
+		appendTogether(document, createSubtree('5', '<p>it works</p>'));
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:5--><p>it works</p><!--/$s:5-->'
+		);
+		expect(document.body.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should replace fallback content when a $p: completion comment arrives', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading...<!--/$s:1--></div>'
+		);
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<p>resolved</p>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>resolved</p><!--/$s:1-->'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should leave $s markers in place and remove the $p: comment after patching', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:9-->fallback<!--/$s:9--></div>'
+		);
+
+		runInitScript(window);
+		const template = appendTemplate(document, '9', '<span>ok</span>');
+		appendPatchComment(template, '9');
+		await flushMutations();
+
+		const comments = [];
+		const iter = document.createNodeIterator(
+			document.body,
+			window.NodeFilter.SHOW_COMMENT
+		);
+		let node;
+		while ((node = iter.nextNode())) comments.push(node.data);
+
+		expect(comments).toEqual(['$s:9', '/$s:9']);
+		expect(document.querySelector('span').textContent).toBe('ok');
+	});
+
+	it('should patch multiple suspense boundaries independently', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->a<!--/$s:1--><!--$s:2-->b<!--/$s:2--></div>'
+		);
+
+		setReadyState(document, 'loading');
+		runInitScript(window);
+		const first = appendTemplate(document, '1', '<p>one</p>');
+		const second = appendTemplate(document, '2', '<p>two</p>');
+		appendPatchComment(first, '1');
+		await flushMutations();
+		appendPatchComment(second, '2');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2--><p>two</p><!--/$s:2-->'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should continue processing later templates when an earlier one has no markers', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>'
+		);
+
+		runInitScript(window);
+		// First template has no matching markers; second should still patch.
+		// A mistaken `return` instead of continuing the addedNodes loop would
+		// abort the batch here. Unmatched stamps are consumed.
+		const skip = appendTemplate(document, 'missing', '<p>skip</p>');
+		const next = appendTemplate(document, '1', '<p>resolved</p>');
+		appendPatchComment(skip, 'missing');
+		appendPatchComment(next, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>resolved</p><!--/$s:1-->'
+		);
+		expect(document.querySelector('template[for="missing"]')).toBeNull();
+		expect(document.querySelector('template[for="1"]')).toBeNull();
+	});
+
+	it('should ignore templates that do not match any suspense markers', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>'
+		);
+
+		runInitScript(window);
+		appendTogether(document, createSubtree('999', '<p>nope</p>'));
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1-->loading<!--/$s:1-->'
+		);
+		expect(document.querySelector('template[for="999"]')).toBeNull();
+	});
+
+	it('should still patch templates when htmlFor is present on HTMLTemplateElement', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>'
+		);
+
+		Object.defineProperty(window.HTMLTemplateElement.prototype, 'htmlFor', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				return this.getAttribute('for');
+			},
+			set(v) {
+				this.setAttribute('for', v);
+			}
+		});
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<p>resolved</p>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>resolved</p><!--/$s:1-->'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should not patch a template that is still streaming while the document is loading', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>'
+		);
+
+		setReadyState(document, 'loading');
+		runInitScript(window);
+
+		const template = appendTemplate(document, '1', '');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1-->loading<!--/$s:1-->'
+		);
+		expect(document.querySelector('template[for="1"]')).not.toBeNull();
+
+		template.innerHTML = '<p>resolved</p>';
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>resolved</p><!--/$s:1-->'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should patch a streamed template once its completion comment arrives', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->a<!--/$s:1--><!--$s:2-->b<!--/$s:2--></div>'
+		);
+
+		setReadyState(document, 'loading');
+		runInitScript(window);
+
+		const first = appendTemplate(document, '1', '<p>one</p>');
+		await flushMutations();
+
+		expect(document.querySelector('template[for="1"]')).not.toBeNull();
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1-->a<!--/$s:1--><!--$s:2-->b<!--/$s:2-->'
+		);
+
+		appendPatchComment(first, '1');
+		const second = appendTemplate(document, '2', '<p>two</p>');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2-->b<!--/$s:2-->'
+		);
+		expect(document.querySelector('template[for="1"]')).toBeNull();
+		expect(document.querySelector('template[for="2"]')).not.toBeNull();
+
+		appendPatchComment(second, '2');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2--><p>two</p><!--/$s:2-->'
+		);
+		expect(document.querySelectorAll('template')).toHaveLength(0);
+	});
+
+	it('should not patch an incomplete template just because another template completes', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--><!--$s:2-->b<!--/$s:2--></div>'
+		);
+
+		setReadyState(document, 'loading');
+		runInitScript(window);
+
+		const partial = appendTemplate(document, '1', '');
+		const complete = appendTemplate(document, '2', '<p>two</p>');
+		appendPatchComment(complete, '2');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1-->loading<!--/$s:1--><!--$s:2--><p>two</p><!--/$s:2-->'
+		);
+		expect(document.querySelector('template[for="1"]')).not.toBeNull();
+		expect(document.querySelector('template[for="2"]')).toBeNull();
+
+		partial.innerHTML = '<p>one</p>';
+		appendPatchComment(partial, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2--><p>two</p><!--/$s:2-->'
+		);
+		expect(document.querySelector('template[for="1"]')).toBeNull();
+	});
+
+	it('should not patch $p: comments already in the document on DOMContentLoaded', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>' +
+				createSubtree('1', '<p>resolved</p>')
+		);
+
+		setReadyState(document, 'loading');
+		runInitScript(window);
+
+		expect(document.querySelector('template[for="1"]')).not.toBeNull();
+
+		setReadyState(document, 'interactive');
+		document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+		expect(document.body.innerHTML).toBe(
+			'<div><!--$s:1-->loading<!--/$s:1--></div><template for="1"><p>resolved</p></template><!--$p:1-->'
+		);
+		expect(document.querySelector('template[for="1"]')).not.toBeNull();
+	});
+
+	it('should disconnect the MutationObserver after a non-loading pass', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->a<!--/$s:1--><!--$s:2-->b<!--/$s:2--></div>'
+		);
+
+		runInitScript(window);
+		const first = appendTemplate(document, '1', '<p>one</p>');
+		appendPatchComment(first, '1');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2-->b<!--/$s:2-->'
+		);
+		expect(document.querySelector('template[for="1"]')).toBeNull();
+
+		const second = appendTemplate(document, '2', '<p>two</p>');
+		appendPatchComment(second, '2');
+		await flushMutations();
+
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>one</p><!--/$s:1--><!--$s:2-->b<!--/$s:2-->'
+		);
+		expect(document.querySelector('template[for="2"]')).not.toBeNull();
+	});
+
+	it('should not reparse sibling svg and math hosts from an HTML hole', async () => {
+		const { window, document } = createDom(
+			'<div><!--$s:1-->loading<!--/$s:1--></div>'
+		);
+
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		svg.appendChild(document.createElement('path'));
+		const math = document.createElementNS(
+			'http://www.w3.org/1998/Math/MathML',
+			'math'
+		);
+		math.appendChild(document.createElement('mi'));
+		document.body.append(svg, math);
+
+		expect(svg.firstChild.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+		expect(math.firstChild.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<p>resolved</p>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(svg.firstChild.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+		expect(math.firstChild.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+		expect(document.querySelector('div').innerHTML).toBe(
+			'<!--$s:1--><p>resolved</p><!--/$s:1-->'
+		);
+	});
+
+	it('should reparse an svg host when the hole is a direct child of it', async () => {
+		const { window, document } = createDom();
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		svg.appendChild(document.createComment('$s:1'));
+		svg.appendChild(document.createElement('path'));
+		svg.appendChild(document.createComment('/$s:1'));
+		document.body.append(svg);
+
+		expect(svg.childNodes[1].namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<circle></circle>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(svg.querySelector('circle')).not.toBeNull();
+		expect(svg.querySelector('circle').namespaceURI).toBe(
+			'http://www.w3.org/2000/svg'
+		);
+		expect(svg.querySelector('path')).toBeNull();
+	});
+
+	it('should reparse an svg host when the hole is nested in an svg child', async () => {
+		const { window, document } = createDom();
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+		group.appendChild(document.createComment('$s:1'));
+		group.appendChild(document.createElement('path'));
+		group.appendChild(document.createComment('/$s:1'));
+		svg.appendChild(group);
+		document.body.append(svg);
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<circle></circle>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(svg.querySelector('circle')).not.toBeNull();
+		expect(svg.querySelector('circle').namespaceURI).toBe(
+			'http://www.w3.org/2000/svg'
+		);
+		expect(svg.querySelector('path')).toBeNull();
+	});
+
+	it('should reparse a math host when the hole is a direct child of it', async () => {
+		const { window, document } = createDom();
+		const math = document.createElementNS(
+			'http://www.w3.org/1998/Math/MathML',
+			'math'
+		);
+		math.appendChild(document.createComment('$s:1'));
+		math.appendChild(document.createElement('mi'));
+		math.appendChild(document.createComment('/$s:1'));
+		document.body.append(math);
+
+		expect(math.childNodes[1].namespaceURI).toBe(
+			'http://www.w3.org/1999/xhtml'
+		);
+
+		runInitScript(window);
+		const template = appendTemplate(document, '1', '<mn>1</mn>');
+		appendPatchComment(template, '1');
+		await flushMutations();
+
+		expect(math.querySelector('mn')).not.toBeNull();
+		expect(math.querySelector('mn').namespaceURI).toBe(
+			'http://www.w3.org/1998/Math/MathML'
+		);
+		expect(math.querySelector('mi')).toBeNull();
+	});
+
+	it('should still reparse svg when native DPU already applied the template', async () => {
+		const { window, document } = createDom();
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		svg.appendChild(document.createComment('$s:1'));
+		// Simulate native DPU: HTML-namespace content already between markers, template gone.
+		svg.appendChild(document.createElement('circle'));
+		svg.appendChild(document.createComment('/$s:1'));
+		document.body.append(svg);
+
+		expect(svg.querySelector('circle').namespaceURI).toBe(
+			'http://www.w3.org/1999/xhtml'
+		);
+
+		runInitScript(window);
+		// Native DPU leaves whitespace before $p:, so previousSibling is a Text node.
+		document.body.appendChild(document.createTextNode('\n'));
+		document.body.appendChild(document.createComment('$p:1'));
+		await flushMutations();
+
+		expect(svg.querySelector('circle')).not.toBeNull();
+		expect(svg.querySelector('circle').namespaceURI).toBe(
+			'http://www.w3.org/2000/svg'
+		);
+	});
+});
 
 describe('stream island races', () => {
-	it('should replace a fallback that has no client-rendered nodes', () => {
-		const { document, root, flush } = setup();
-		appendIsland(document);
-		flush();
+	let dom;
+	const previousDocument = globalThis.document;
+	afterEach(() => {
+		dom.window.close();
+		globalThis.document = previousDocument;
+	});
+
+	function setup(
+		html = '<div id="root"><!--$s:1--><i>loading</i><!--/$s:1--></div>'
+	) {
+		const created = createDom(html);
+		dom = created.dom;
+		globalThis.document = created.document;
+		runInitScript(created.window);
+		return {
+			document: created.document,
+			root: created.document.querySelector('#root')
+		};
+	}
+
+	function appendPatch(document, content = '<button>server</button>') {
+		document.body.insertAdjacentHTML('beforeend', createSubtree('1', content));
+	}
+
+	function renderClient(root, children) {
+		root.replaceChildren();
+		render(children, root);
+		// Keep the stream anchors, as resumed hydration does in Preact 11.
+		root.prepend(document.createComment('$s:1'));
+		root.append(document.createComment('/$s:1'));
+	}
+
+	it('should replace a fallback that has no client-rendered nodes', async () => {
+		const { document, root } = setup();
+		appendPatch(document);
+		await flushMutations();
 		expect(root.innerHTML).toBe(
 			'<!--$s:1--><button>server</button><!--/$s:1-->'
 		);
-		expect(document.querySelector('preact-island')).toBeNull();
+		expect(document.querySelector('template[for]')).toBeNull();
 	});
 
-	it('should preserve client nodes rendered before the island connects', () => {
-		const { document, root, flush } = setup();
+	it('should preserve client nodes rendered before the patch is applied', async () => {
+		const { document, root } = setup();
 		let clicks = 0;
 		renderClient(root, <button onClick={() => clicks++}>client</button>);
 		const button = root.querySelector('button');
 		const fallback = document.createElement('i');
 		fallback.textContent = 'loading';
 		root.insertBefore(fallback, root.lastChild);
-		appendIsland(document);
-		flush();
+		appendPatch(document);
+		await flushMutations();
 		expect(root.querySelector('button')).toBe(button);
 		expect(root.textContent).toBe('client');
 		button.click();
 		expect(clicks).toBe(1);
-		expect(document.querySelector('preact-island')).toBeNull();
+		expect(document.querySelector('template[for]')).toBeNull();
 	});
 
-	it('should recheck client ownership after the animation frame is queued', () => {
-		const { document, root, flush } = setup();
-		appendIsland(document);
-		// Preserve the same anchors, but let the client create content between them.
+	it('should recheck client ownership after the patch is queued', async () => {
+		const { document, root } = setup();
+		appendPatch(document);
+		// Preserve the same anchors, but let the client create content between them
+		// before the observer runs.
 		const start = root.firstChild;
 		const end = root.lastChild;
 		let clicks = 0;
@@ -82,47 +601,48 @@ describe('stream island races', () => {
 		root.prepend(start);
 		root.append(end);
 		const button = root.querySelector('button');
-		flush();
+		await flushMutations();
 		expect(root.querySelector('button')).toBe(button);
 		button.click();
 		expect(clicks).toBe(1);
-		expect(document.querySelector('preact-island')).toBeNull();
+		expect(document.querySelector('template[for]')).toBeNull();
 	});
 
-	it('should discard an island when hydration removed the anchors before its frame', () => {
-		const { document, root, flush } = setup();
-		appendIsland(document);
+	it('should discard a patch when hydration removed the anchors before it runs', async () => {
+		const { document, root } = setup();
+		appendPatch(document);
 		root.replaceChildren();
 		render(<button>client</button>, root);
 		const button = root.firstChild;
-		expect(() => flush()).not.toThrow();
+		await expect(flushMutations()).resolves.toBeUndefined();
 		expect(root.firstChild).toBe(button);
 		expect(root.textContent).toBe('client');
-		expect(document.querySelector('preact-island')).toBeNull();
+		expect(document.querySelector('template[for]')).toBeNull();
 	});
 
-	it('should discard an island when its boundary has already disappeared', () => {
-		const { document, root, flush } = setup();
+	it('should discard a patch when its boundary has already disappeared', async () => {
+		const { document, root } = setup();
 		root.replaceChildren();
 		render(<button>client</button>, root);
-		appendIsland(document);
-		flush();
+		appendPatch(document);
+		await flushMutations();
 		expect(root.textContent).toBe('client');
-		expect(document.querySelector('preact-island')).toBeNull();
+		expect(document.querySelector('template[for]')).toBeNull();
 	});
 
-	it('should preserve client text and multiple sibling elements', () => {
-		const { document, root, flush } = setup();
+	it('should preserve client text and multiple sibling elements', async () => {
+		const { document, root } = setup();
 		renderClient(root, ['client text', <button>one</button>, <span>two</span>]);
 		const nodes = Array.from(root.childNodes);
-		appendIsland(document, '<button>server</button><span>server</span>');
-		flush();
+		appendPatch(document, '<button>server</button><span>server</span>');
+		await flushMutations();
 		expect(root.childNodes.length).toBe(nodes.length);
 		nodes.forEach((node, i) => expect(root.childNodes[i]).toBe(node));
 		expect(root.textContent).toBe('client textonetwo');
 	});
-	it('should not mistake a hydrated sibling outside the boundary for resolved content', () => {
-		const { document, root, flush } = setup();
+
+	it('should not mistake a hydrated sibling outside the boundary for resolved content', async () => {
+		const { document, root } = setup();
 		root.replaceChildren();
 		render(
 			<main>
@@ -133,25 +653,25 @@ describe('stream island races', () => {
 		);
 		const section = root.querySelector('section');
 		section.innerHTML = '<!--$s:1--><i>loading</i><!--/$s:1-->';
-		appendIsland(document);
-		flush();
+		appendPatch(document);
+		await flushMutations();
 		expect(section.textContent).toBe('server');
 		expect(root.querySelector('button').textContent).toBe('outside');
 	});
 
-	it('should preserve input state even when the element has no DOM mutations', () => {
-		const { document, root, flush } = setup();
+	it('should preserve input state even when the element has no DOM mutations', async () => {
+		const { document, root } = setup();
 		renderClient(root, <input defaultValue="initial" />);
 		const input = root.querySelector('input');
 		input.value = 'edited';
-		appendIsland(document, '<input value="initial">');
-		flush();
+		appendPatch(document, '<input value="initial">');
+		await flushMutations();
 		expect(root.querySelector('input')).toBe(input);
 		expect(input.value).toBe('edited');
 	});
 
-	it('should retain nested suspended boundaries while discarding the outer patch', () => {
-		const { document, root, flush } = setup();
+	it('should retain nested suspended boundaries while discarding the outer patch', async () => {
+		const { document, root } = setup();
 		renderClient(root, <button>client</button>);
 		root
 			.querySelector('button')
@@ -159,8 +679,8 @@ describe('stream island races', () => {
 				'afterend',
 				'<!--$s:2--><i>nested fallback</i><!--/$s:2-->'
 			);
-		appendIsland(document);
-		flush();
+		appendPatch(document);
+		await flushMutations();
 		expect(root.innerHTML).toBe(
 			'<!--$s:1--><button>client</button><!--$s:2--><i>nested fallback</i><!--/$s:2--><!--/$s:1-->'
 		);

--- a/test/compat/render-chunked.test.jsx
+++ b/test/compat/render-chunked.test.jsx
@@ -17,6 +17,11 @@ describe('renderToChunks', () => {
 		expect(result).toEqual(['<div class="foo">bar</div>']);
 	});
 
+	it('should include MutationObserver replace helper in the init script', () => {
+		expect(createInitScript()).toContain('MutationObserver');
+		expect(createSubtree('1', '<p>x</p>')).toContain('template for="1"');
+	});
+
 	it('should render fallback + attach loaded subtree on suspend', async () => {
 		const { Suspender, suspended } = createSuspender();
 
@@ -34,11 +39,9 @@ describe('renderToChunks', () => {
 		await promise;
 
 		expect(result).to.deep.equal([
-			'<div><!--$s:5-->loading...<!--/$s:5--></div>',
-			'<div hidden>',
+			`<div><!--$s:5--><?start name="5">loading...<?end><!--/$s:5--></div>`,
 			createInitScript(),
-			createSubtree('5', '<p>it works</p>'),
-			'</div>'
+			createSubtree('5', '<p>it works</p>')
 		]);
 	});
 
@@ -62,10 +65,8 @@ describe('renderToChunks', () => {
 		suspended.resolve();
 
 		expect(result).to.deep.equal([
-			'<div><!--$s:10-->loading...<!--/$s:10--></div>',
-			'<div hidden>',
-			createInitScript(),
-			'</div>'
+			`<div><!--$s:10--><?start name="10">loading...<?end><!--/$s:10--></div>`,
+			createInitScript()
 		]);
 	});
 
@@ -109,11 +110,9 @@ describe('renderToChunks', () => {
 		}
 
 		expect(result).to.deep.equal([
-			'<div><!--$s:16-->loading...<!--/$s:16--></div>',
-			'<div hidden>',
+			`<div><!--$s:16--><?start name="16">loading...<?end><!--/$s:16--></div>`,
 			createInitScript(),
-			createSubtree('16', '<p>it works</p>'),
-			'</div>'
+			createSubtree('16', '<p>it works</p>')
 		]);
 	});
 
@@ -142,11 +141,9 @@ describe('renderToChunks', () => {
 		await promise;
 
 		expect(result).to.deep.equal([
-			'<div><p>id: P0-0</p><!--$s:24-->loading...<!--/$s:24--></div>',
-			'<div hidden>',
+			`<div><p>id: P0-0</p><!--$s:24--><?start name="24">loading...<?end><!--/$s:24--></div>`,
 			createInitScript(),
-			createSubtree('24', '<p>id: P0-1</p>'),
-			'</div>'
+			createSubtree('24', '<p>id: P0-1</p>')
 		]);
 	});
 
@@ -182,12 +179,10 @@ describe('renderToChunks', () => {
 		await promise;
 
 		expect(result).toEqual([
-			'<div><p>id: P0-0</p><!--$s:33-->loading...<!--/$s:33--><!--$s:36-->loading...<!--/$s:36--></div>',
-			'<div hidden>',
+			`<div><p>id: P0-0</p><!--$s:33--><?start name="33">loading...<?end><!--/$s:33--><!--$s:36--><?start name="36">loading...<?end><!--/$s:36--></div>`,
 			createInitScript(),
 			createSubtree('33', '<p>id: P0-1</p>'),
-			createSubtree('36', '<p>id: P0-2</p>'),
-			'</div>'
+			createSubtree('36', '<p>id: P0-2</p>')
 		]);
 	});
 
@@ -213,8 +208,8 @@ describe('renderToChunks', () => {
 
 		const fullHtml = result.join('');
 
-		// Deferred wrapper must appear before </body></html>, not after
-		const deferredPos = fullHtml.indexOf('<div hidden>');
+		// Deferred init script / templates must appear before </body></html>, not after
+		const deferredPos = fullHtml.indexOf(createInitScript());
 		const bodyClosePos = fullHtml.indexOf('</body>');
 		const htmlClosePos = fullHtml.indexOf('</html>');
 
@@ -305,11 +300,9 @@ describe('renderToChunks', () => {
 		await promise;
 
 		expect(result).to.deep.equal([
-			'<div><!--$s:70-->loading part 1...<!--/$s:70--></div>',
-			'<div hidden>',
+			`<div><!--$s:70--><?start name="70">loading part 1...<?end><!--/$s:70--></div>`,
 			createInitScript(),
-			createSubtree('70', '<p>it works</p><p>it works</p>'),
-			'</div>'
+			createSubtree('70', '<p>it works</p><p>it works</p>')
 		]);
 	});
 
@@ -332,7 +325,7 @@ describe('renderToChunks', () => {
 		expect(fullHtml).to.contain('<script nonce="r4nd0m-nonce">');
 
 		// The init script should be the only script emitted
-		expect(result[2]).to.equal(createInitScript('r4nd0m-nonce'));
+		expect(result[1]).to.equal(createInitScript('r4nd0m-nonce'));
 	});
 
 	it.each([
@@ -357,11 +350,9 @@ describe('renderToChunks', () => {
 
 			const id = result[0].match(/\$s:(\d+)/)[1];
 			expect(result).toEqual([
-				`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
-				'<div hidden>',
+				`<!--$s:${id}--><?start name="${id}">loading...<?end><!--/$s:${id}-->`,
 				createInitScript(),
-				createSubtree(id, ''),
-				'</div>'
+				createSubtree(id, '')
 			]);
 		}
 	);
@@ -385,13 +376,13 @@ describe('renderToChunks', () => {
 		first.suspended.resolve();
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(
-			result.filter((chunk) => chunk.startsWith('<preact-island'))
+			result.filter((chunk) => chunk.startsWith('<template'))
 		).toEqual([]);
 
 		second.suspended.resolve();
 		await promise;
 		const patches = result.filter((chunk) =>
-			chunk.startsWith('<preact-island')
+			chunk.startsWith('<template')
 		);
 		expect(patches).toHaveLength(1);
 		expect(patches[0]).toContain('<p>first</p><p>second</p>');

--- a/test/compat/stream-node.test.jsx
+++ b/test/compat/stream-node.test.jsx
@@ -66,11 +66,9 @@ describe('renderToPipeableStream', () => {
 		const result = await sink.promise;
 
 		expect(result).to.deep.equal([
-			'<div><!--$s:5-->loading...<!--/$s:5--></div>',
-			'<div hidden>',
+			`<div><!--$s:5--><?start name="5">loading...<?end><!--/$s:5--></div>`,
 			createInitScript(),
-			createSubtree('5', '<p>it works</p>'),
-			'</div>'
+			createSubtree('5', '<p>it works</p>')
 		]);
 	});
 
@@ -130,11 +128,9 @@ describe('renderToPipeableStream', () => {
 		const result = await sink.promise;
 		const id = result[0].match(/\$s:(\d+)/)[1];
 		expect(result).toEqual([
-			`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
-			'<div hidden>',
+			`<!--$s:${id}--><?start name="${id}">loading...<?end><!--/$s:${id}-->`,
 			createInitScript(),
-			createSubtree(id, ''),
-			'</div>'
+			createSubtree(id, '')
 		]);
 	});
 });

--- a/test/compat/stream.test.jsx
+++ b/test/compat/stream.test.jsx
@@ -83,11 +83,9 @@ describe('renderToReadableStream', () => {
 		const result = await sink.promise;
 
 		expect(result).toEqual([
-			'<div><!--$s:5-->loading...<!--/$s:5--></div>',
-			'<div hidden>',
+			`<div><!--$s:5--><?start name="5">loading...<?end><!--/$s:5--></div>`,
 			createInitScript(),
-			createSubtree('5', '<p>it works</p>'),
-			'</div>'
+			createSubtree('5', '<p>it works</p>')
 		]);
 	});
 
@@ -124,11 +122,9 @@ describe('renderToReadableStream', () => {
 		const result = await sink.promise;
 		const id = result[0].match(/\$s:(\d+)/)[1];
 		expect(result).toEqual([
-			`<!--$s:${id}-->loading...<!--/$s:${id}-->`,
-			'<div hidden>',
+			`<!--$s:${id}--><?start name="${id}">loading...<?end><!--/$s:${id}-->`,
 			createInitScript(),
-			createSubtree(id, ''),
-			'</div>'
+			createSubtree(id, '')
 		]);
 	});
 });


### PR DESCRIPTION
This is an alternative DPU template for streaming using an HTML end-stamp comment to let the mutation observer know when to run replacement code.  This approach is more targeted and, in theory, more reliable than #474  for race conditions or edge cases, at the cost of slightly more HTML for each boundary  of about 9 bytes per resolved suspence boundary resulting in a this sending more html at about 8 boundaries. 

| Metric | main | branch | Δ |
|--------|-----:|-------:|--:|
| INIT_SCRIPT body | 1135 | 1066 | −69 |
| createInitScript() tag | 1168 | 1099 | −69 |
| createSubtree() | 69 | 55 | −14 |
| Suspense fallback wrapper | 33 | 56 | +23 |
| One boundary stamp overhead | 77 | 86 | +9 |
| First suspend total (stamps + init) | 1245 | 1185 | −60 |


code sand box link to use this PR can be seen here
https://ci.codesandbox.io/status/MaxwellCohen/preact-render-to-string/pr/6/builds/691802