### PR TITLE
Fix Changesets release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "format": false,
   "updateInternalDependencies": "patch",
   "ignore": []
 }


### PR DESCRIPTION
Disable Changesets' automatic formatter detection. Markdown is intentionally ignored by oxfmt, so formatting the generated changelog exits without a target and blocks release PR creation.